### PR TITLE
Fix add and commit all

### DIFF
--- a/noteable_magics/git_service.py
+++ b/noteable_magics/git_service.py
@@ -144,5 +144,5 @@ class GitService:
         return GitInit(created=False)
 
     def add_and_commit_all(self, message: Optional[str] = None):
-        self._repo.git.add(A=True)
-        self._repo.git.commit("-m", message or "updated project files", "--allow-empty")
+        self.repo.git.add(A=True)
+        self.repo.git.commit("-m", message or "updated project files", "--allow-empty")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 authors = ["Eli Wilson <eli@noteable.io>"]
 description = "IPython Magics for Noteable"
 name = "noteable_magics"
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.poetry.dependencies]
 GitPython = "^3.1.14"


### PR DESCRIPTION
If `%ntbl project pull` was called before some other command, it would fail because `self._repo` was not initialized as a git repository yet