### PR TITLE
Some quality of life improvements

### DIFF
--- a/noteable_magics/data_loader.py
+++ b/noteable_magics/data_loader.py
@@ -77,7 +77,7 @@ class NoteableDataLoaderMagic(Magics, Configurable):
             print(f"Connect with: %sql {conn.name}")
         if self.display_example:
             print(
-                "Create a new SQL cell and then input query. "
+                "Create a SQL cell and then input query. "
                 f"Example: \"SELECT * FROM '{tablename}' LIMIT 10\""
             )
         if self.return_head:


### PR DESCRIPTION
1. Don't display the connection string by default anymore (but still configurable)
2. Display the example SQL
3. Add a config value to not return the pandas df head

@Matt-the-bot can you review the copy for "Create a new SQL cell then run: SELECT * FROM '{tablename}' LIMIT 10"?