### PR TITLE
Eng 4176 update the magic output for the noteable magic expression that slurps cs vs and populates sqlite

### DIFF
--- a/noteable_magics/data_loader.py
+++ b/noteable_magics/data_loader.py
@@ -87,7 +87,7 @@ class NoteableDataLoaderMagic(Magics, Configurable):
         if self.display_example:
             print(
                 """Create a "Local Database" SQL cell and then input query. """
-                f"Example: \"SELECT * FROM \"{tablename}\" LIMIT 10\""
+                f"Example: 'SELECT * FROM \"{tablename}\" LIMIT 10'"
             )
         if self.return_head:
             return tmp_df.head(self.pandas_limit)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Better string message as a result of running the data importer -- more specific about type of cell, use right style quotes around the table name so will be directly pasteable.
  - Was: `Create a SQL cell and then input query. Example: "SELECT * from 'tablename' LIMIT 10"`
  - Now: `Create a "Local Database" SQL cell and then input query. Example: 'SELECT * FROM "sdf" LIMIT 10' `
