### PR TITLE
Incorporate the source code present in ipython-sql-noteable ...

### DIFF
--- a/noteable_magics/__init__.py
+++ b/noteable_magics/__init__.py
@@ -2,12 +2,12 @@ import pkg_resources
 
 __version__ = pkg_resources.get_distribution("noteable_magics").version
 
-from sql.run import add_commit_blacklist_dialect
-
 from .data_loader import LOCAL_DB_CONN_HANDLE, NoteableDataLoaderMagic, get_db_connection
 from .datasources import bootstrap_datasources
 from .logging import configure_logging
 from .ntbl import NTBLMagic
+from .sql.magic import SqlMagic
+from .sql.run import add_commit_blacklist_dialect
 
 
 def load_ipython_extension(ipython):
@@ -24,4 +24,4 @@ def load_ipython_extension(ipython):
 
     configure_logging(False, "INFO", "DEBUG")
 
-    ipython.register_magics(NoteableDataLoaderMagic, NTBLMagic)
+    ipython.register_magics(NoteableDataLoaderMagic, NTBLMagic, SqlMagic)

--- a/noteable_magics/data_loader.py
+++ b/noteable_magics/data_loader.py
@@ -5,9 +5,10 @@ import pandas as pd
 from IPython.core.magic import Magics, line_cell_magic, magics_class
 from IPython.core.magic_arguments import argument, magic_arguments
 from IPython.utils.process import arg_split
-from sql.connection import Connection
 from traitlets import Bool, Int
 from traitlets.config import Configurable
+
+from noteable_magics.sql.connection import Connection
 
 EXCEL_MIMETYPES = {
     "application/vnd.ms-excel",  # .xls

--- a/noteable_magics/datasources.py
+++ b/noteable_magics/datasources.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import pkg_resources
+from sqlalchemy.engine import URL
 
 # ipython-sql thinks mighty highly of isself with this package name.
-import sql.connection
-from sql.run import add_commit_blacklist_dialect
-from sqlalchemy.engine import URL
+import noteable_magics.sql.connection
+from noteable_magics.sql.run import add_commit_blacklist_dialect
 
 DEFAULT_SECRETS_DIR = Path('/vault/secrets')
 
@@ -114,7 +114,7 @@ def bootstrap_datasource(
     human_name = metadata.get('name')
 
     # Teach ipython-sql about it!
-    sql.connection.Connection.set(
+    noteable_magics.sql.connection.Connection.set(
         connection_url,
         name=f'@{datasource_id}',
         human_name=human_name,

--- a/noteable_magics/sql/LICENSE
+++ b/noteable_magics/sql/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Portions Copyright (c) 2014 Catherine Devlin 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/noteable_magics/sql/__init__.py
+++ b/noteable_magics/sql/__init__.py
@@ -1,0 +1,1 @@
+from .magic import *

--- a/noteable_magics/sql/column_guesser.py
+++ b/noteable_magics/sql/column_guesser.py
@@ -1,0 +1,96 @@
+"""
+Splits tabular data in the form of a list of rows into columns;
+makes guesses about the role of each column for plotting purposes
+(X values, Y values, and text labels).
+"""
+
+
+class Column(list):
+    "Store a column of tabular data; record its name and whether it is numeric"
+    is_quantity = True
+    name = ""
+
+    def __init__(self, *arg, **kwarg):
+        pass
+
+
+def is_quantity(val):
+    """Is ``val`` a quantity (int, float, datetime, etc) (not str, bool)?
+    
+    Relies on presence of __sub__.
+    """
+    return hasattr(val, "__sub__")
+
+
+class ColumnGuesserMixin(object):
+    """
+    plot: [x, y, y...], y
+    pie: ... y
+    """
+
+    def _build_columns(self):
+        self.columns = [Column() for col in self.keys]
+        for row in self:
+            for (col_idx, col_val) in enumerate(row):
+                col = self.columns[col_idx]
+                col.append(col_val)
+                if (col_val is not None) and (not is_quantity(col_val)):
+                    col.is_quantity = False
+
+        for (idx, key_name) in enumerate(self.keys):
+            self.columns[idx].name = key_name
+
+        self.x = Column()
+        self.ys = []
+
+    def _get_y(self):
+        for idx in range(len(self.columns) - 1, -1, -1):
+            if self.columns[idx].is_quantity:
+                self.ys.insert(0, self.columns.pop(idx))
+                return True
+
+    def _get_x(self):
+        for idx in range(len(self.columns)):
+            if self.columns[idx].is_quantity:
+                self.x = self.columns.pop(idx)
+                return True
+
+    def _get_xlabel(self, xlabel_sep=" "):
+        self.xlabels = []
+        if self.columns:
+            for row_idx in range(len(self.columns[0])):
+                self.xlabels.append(
+                    xlabel_sep.join(str(c[row_idx]) for c in self.columns)
+                )
+        self.xlabel = ", ".join(c.name for c in self.columns)
+
+    def _guess_columns(self):
+        self._build_columns()
+        self._get_y()
+        if not self.ys:
+            raise AttributeError("No quantitative columns found for chart")
+
+    def guess_pie_columns(self, xlabel_sep=" "):
+        """
+        Assigns x, y, and x labels from the data set for a pie chart.
+        
+        Pie charts simply use the last quantity column as 
+        the pie slice size, and everything else as the
+        pie slice labels.
+        """
+        self._guess_columns()
+        self._get_xlabel(xlabel_sep)
+
+    def guess_plot_columns(self):
+        """
+        Assigns ``x`` and ``y`` series from the data set for a plot.
+        
+        Plots use:
+          the rightmost quantity column as a Y series
+          optionally, the leftmost quantity column as the X series
+          any other quantity columns as additional Y series
+        """
+        self._guess_columns()
+        self._get_x()
+        while self._get_y():
+            pass

--- a/noteable_magics/sql/connection.py
+++ b/noteable_magics/sql/connection.py
@@ -1,0 +1,170 @@
+import os
+from typing import Optional
+
+import sqlalchemy
+from sqlalchemy.engine import Engine
+
+
+class ConnectionError(Exception):
+    pass
+
+
+def rough_dict_get(dct, sought, default=None):
+    """
+    Like dct.get(sought), but any key containing sought will do.
+
+    If there is a `@` in sought, seek each piece separately.
+    This lets `me@server` match `me:***@myserver/db`
+    """
+
+    sought = sought.split("@")
+    for (key, val) in dct.items():
+        if not any(s.lower() not in key.lower() for s in sought):
+            return val
+    return default
+
+
+class Connection(object):
+    current = None
+    connections = {}
+
+    @classmethod
+    def tell_format(cls):
+        return """Connection info needed in SQLAlchemy format, example:
+               postgresql://username:password@hostname/dbname
+               or an existing connection: %s""" % str(
+            cls.connections.keys()
+        )
+
+    def __init__(self, connect_str=None, name=None, human_name=None, **create_engine_kwargs):
+        """
+        Construct + register a new 'connection', which in reality is a sqla Engine
+        plus some convienent metadata.
+
+        Common args to go into the create_engine call (and therefore need to be
+        passed in within `create_engine_kwargs`) include:
+
+          * connect_args: SQLA will pass these down to its call to create the DBAPI-level
+                            connection class when new low-level connections are
+                            established.
+
+          * creator: Callable which itself returns the DBAPI connection. See
+            https://docs-sqlalchemy.readthedocs.io/ko/latest/core/engines.html#custom-dbapi-connect-arguments
+
+        Sets the 'current' connection to the newly init'd one.
+
+        No session is immediately established (see the session property).
+
+        'name' is what we call now the 'sql_cell_handle' -- starts with '@', followed by
+        the hex of the datasource uuid (usually -- the legacy sqlite and bigquery do not
+        use the hex convention because they predate datasources)
+
+        'human_name' is the name that the user gave the datasource ('My PostgreSQL Connection')
+        (again, only for real datasource connections). There's a slight risk of name collision
+        due to having the same name used between user and space scopes, but so be it.
+
+        """
+        if name and not name.startswith("@"):
+            raise ValueError("preassigned names must start with @")
+
+        if "creator" in create_engine_kwargs and create_engine_kwargs["creator"] is None:
+            # As called from sql.magic in calling sql.connection.Connection.set,
+            # will always pass kwarg 'creator', but it will most likely be None.
+            # SQLA does not like it passed in as None (will still try to call it).
+            # So must remove the dict. Is cause for why legacy BigQuery connection
+            # fails.
+            del create_engine_kwargs["creator"]
+
+        try:
+            self._engine = sqlalchemy.create_engine(connect_str, **create_engine_kwargs)
+        except Exception:  # TODO: bare-ish except; but what's an ArgumentError?
+            print(self.tell_format())
+            raise
+
+        self.dialect = self._engine.url.get_dialect()
+        self.metadata = sqlalchemy.MetaData(bind=self._engine)
+        self.name = name or self.assign_name(self._engine)
+        self.human_name = human_name
+        self._session = None
+        self.connections[name or repr(self.metadata.bind.url)] = self
+
+        Connection.current = self
+
+    @property
+    def session(self):
+        """Lazily connect to the database."""
+
+        if not self._session:
+            self._session = self._engine.connect()
+        return self._session
+
+    @classmethod
+    def set(cls, descriptor, displaycon, name=None, **create_engine_kwargs):
+        "Sets the current database connection"
+
+        if descriptor:
+            if isinstance(descriptor, Connection):
+                cls.current = descriptor
+            else:
+                existing = rough_dict_get(cls.connections, descriptor)
+                # http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#custom-dbapi-connect-arguments
+                cls.current = existing or Connection(
+                    descriptor,
+                    name,
+                    **create_engine_kwargs,
+                )
+        else:
+            if cls.connections:
+                if displaycon:
+                    print(cls.connection_list())
+            else:
+                if os.getenv("DATABASE_URL"):
+                    cls.current = Connection(os.getenv("DATABASE_URL"), **create_engine_kwargs)
+                else:
+                    raise ConnectionError(
+                        "Environment variable $DATABASE_URL not set, and no connect string given."
+                    )
+        return cls.current
+
+    @classmethod
+    def assign_name(cls, engine):
+        name = "%s@%s" % (engine.url.username or "", engine.url.database)
+        return name
+
+    @classmethod
+    def connection_list(cls):
+        result = []
+        for key in sorted(cls.connections):
+            engine_url = cls.connections[key].metadata.bind.url  # type: sqlalchemy.engine.url.URL
+            if cls.connections[key] == cls.current:
+                template = " * {}"
+            else:
+                template = "   {}"
+            result.append(template.format(engine_url.__repr__()))
+        return "\n".join(result)
+
+    @classmethod
+    def get_engine(cls, name: str) -> Optional[Engine]:
+        """Return the SQLAlchemy Engine given either the sql_cell_handle or
+        end-user assigned name for the connection.
+        """
+        for c in cls.connections.values():
+            if c.name == name or c.human_name == name:
+                return c._engine
+
+    def _close(cls, descriptor):
+        if isinstance(descriptor, Connection):
+            conn = descriptor
+        else:
+            conn = cls.connections.get(descriptor) or cls.connections.get(descriptor.lower())
+        if not conn:
+            raise Exception(
+                "Could not close connection because it was not found amongst these: %s"
+                % str(cls.connections.keys())
+            )
+        cls.connections.pop(conn.name, None)
+        cls.connections.pop(str(conn.metadata.bind.url), None)
+        conn.session.close()
+
+    def close(self):
+        self.__class__._close(self)

--- a/noteable_magics/sql/magic.py
+++ b/noteable_magics/sql/magic.py
@@ -1,0 +1,326 @@
+import json
+import re
+from string import Formatter
+
+from IPython.core.magic import Magics, cell_magic, line_magic, magics_class, needs_local_scope
+from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
+from sqlalchemy.exc import (
+    DatabaseError,
+    InterfaceError,
+    InternalError,
+    OperationalError,
+    ProgrammingError,
+)
+
+import noteable_magics.sql.connection
+import noteable_magics.sql.parse
+import noteable_magics.sql.run
+
+try:
+    from traitlets import Bool, Int, Unicode
+    from traitlets.config.configurable import Configurable
+except ImportError:
+    from IPython.config.configurable import Configurable
+    from IPython.utils.traitlets import Bool, Int, Unicode
+try:
+    from pandas.core.frame import DataFrame, Series
+except ImportError:
+    DataFrame = None
+    Series = None
+
+
+@magics_class
+class SqlMagic(Magics, Configurable):
+    """Runs SQL statement on a database, specified by SQLAlchemy connect string.
+
+    Provides the %%sql magic."""
+
+    displaycon = Bool(True, config=True, help="Show connection string after execute")
+    autolimit = Int(
+        0,
+        config=True,
+        allow_none=True,
+        help="Automatically limit the size of the returned result sets",
+    )
+    style = Unicode(
+        "DEFAULT",
+        config=True,
+        help="Set the table printing style to any of prettytable's defined styles (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)",
+    )
+    short_errors = Bool(
+        True,
+        config=True,
+        help="Don't display the full traceback on SQL Programming Error",
+    )
+    displaylimit = Int(
+        None,
+        config=True,
+        allow_none=True,
+        help="Automatically limit the number of rows displayed (full result set is still stored)",
+    )
+    autopandas = Bool(
+        False,
+        config=True,
+        help="Return Pandas DataFrames instead of regular result sets",
+    )
+    column_local_vars = Bool(
+        False, config=True, help="Return data into local variables from column names"
+    )
+    feedback = Bool(True, config=True, help="Print number of rows affected by DML")
+    dsn_filename = Unicode(
+        "odbc.ini",
+        config=True,
+        help="Path to DSN file. "
+        "When the first argument is of the form [section], "
+        "a sqlalchemy connection string is formed from the "
+        "matching section in the DSN file.",
+    )
+    autocommit = Bool(True, config=True, help="Set autocommit mode")
+
+    def __init__(self, shell):
+        Configurable.__init__(self, config=shell.config)
+        Magics.__init__(self, shell=shell)
+
+        # Add ourself to the list of module configurable via %config
+        self.shell.configurables.append(self)
+
+    @needs_local_scope
+    @line_magic("sql")
+    @cell_magic("sql")
+    @magic_arguments()
+    @argument("line", default="", nargs="*", type=str, help="sql")
+    @argument("-l", "--connections", action="store_true", help="list active connections")
+    @argument("-x", "--close", type=str, help="close a session by name")
+    @argument("-c", "--creator", type=str, help="specify creator function for new connection")
+    @argument(
+        "-s",
+        "--section",
+        type=str,
+        help="section of dsn_file to be used for generating a connection string",
+    )
+    @argument(
+        "-p",
+        "--persist",
+        action="store_true",
+        help="create a table name in the database from the named DataFrame",
+    )
+    @argument(
+        "--append",
+        action="store_true",
+        help="create, or append to, a table name in the database from the named DataFrame",
+    )
+    @argument(
+        "-a",
+        "--connection_arguments",
+        type=str,
+        help="specify dictionary of connection arguments to pass to SQL driver",
+    )
+    @argument("-f", "--file", type=str, help="Run SQL from file at this path")
+    def execute(self, line="", cell="", local_ns={}):
+        """Runs SQL statement against a database, specified by SQLAlchemy connect string.
+
+        If no database connection has been established, first word
+        should be a SQLAlchemy connection string, or the user@db name
+        of an established connection.
+
+        Examples::
+
+          %%sql postgresql://me:mypw@localhost/mydb
+          SELECT * FROM mytable
+
+          %%sql me@mydb
+          DELETE FROM mytable
+
+          %%sql
+          DROP TABLE mytable
+
+        SQLAlchemy connect string syntax examples:
+
+          postgresql://me:mypw@localhost/mydb
+          sqlite://
+          mysql+pymysql://me:mypw@localhost/mydb
+
+        """
+        # Parse variables (words wrapped in {}) for %%sql magic (for %sql this is done automatically)
+        cell_variables = [fn for _, fn, _, _ in Formatter().parse(cell) if fn is not None]
+        cell_params = {}
+        for variable in cell_variables:
+            if variable in local_ns:
+                cell_params[variable] = local_ns[variable]
+            else:
+                raise NameError(variable)
+        cell = cell.format(**cell_params)
+
+        line = noteable_magics.sql.parse.without_sql_comment(parser=self.execute.parser, line=line)
+        args = parse_argstring(self.execute, line)
+        if args.connections:
+            return noteable_magics.sql.connection.Connection.connections
+        elif args.close:
+            return noteable_magics.sql.connection.Connection._close(args.close)
+
+        # save globals and locals so they can be referenced in bind vars
+        user_ns = self.shell.user_ns.copy()
+        user_ns.update(local_ns)
+
+        command_text = " ".join(args.line) + "\n" + cell
+
+        if args.file:
+            with open(args.file, "r") as infile:
+                command_text = infile.read() + "\n" + command_text
+
+        parsed = noteable_magics.sql.parse.parse(command_text, self)
+
+        connect_str = parsed["connection"]
+        if args.section:
+            connect_str = noteable_magics.sql.parse.connection_from_dsn_section(args.section, self)
+
+        if args.connection_arguments:
+            try:
+                # check for string deliniators, we need to strip them for json parse
+                raw_args = args.connection_arguments
+                if len(raw_args) > 1:
+                    targets = ['"', "'"]
+                    head = raw_args[0]
+                    tail = raw_args[-1]
+                    if head in targets and head == tail:
+                        raw_args = raw_args[1:-1]
+                args.connection_arguments = json.loads(raw_args)
+            except Exception as e:
+                print(e)
+                raise e
+        else:
+            args.connection_arguments = {}
+        if args.creator:
+            args.creator = user_ns[args.creator]
+
+        try:
+            conn = noteable_magics.sql.connection.Connection.set(
+                connect_str,
+                displaycon=self.displaycon,
+                connect_args=args.connection_arguments,
+                creator=args.creator,
+            )
+        except Exception as e:
+            print(e)
+            print(noteable_magics.sql.connection.Connection.tell_format())
+            return None
+
+        if args.persist:
+            return self._persist_dataframe(parsed["sql"], conn, user_ns, append=False)
+
+        if args.append:
+            return self._persist_dataframe(parsed["sql"], conn, user_ns, append=True)
+
+        if not parsed["sql"]:
+            return
+
+        try:
+            result = noteable_magics.sql.run.run(conn, parsed["sql"], self, user_ns)
+
+            if result is not None and not isinstance(result, str) and self.column_local_vars:
+                # Instead of returning values, set variables directly in the
+                # users namespace. Variable names given by column names
+
+                if self.autopandas:
+                    keys = result.keys()
+                else:
+                    keys = result.keys
+                    result = result.dict()
+
+                if self.feedback:
+                    print("Returning data to local variables [{}]".format(", ".join(keys)))
+
+                self.shell.user_ns.update(result)
+
+                return None
+            else:
+
+                if parsed["result_var"]:
+                    result_var = parsed["result_var"]
+                    print("Returning data to local variable {}".format(result_var))
+                    self.shell.user_ns.update({result_var: result})
+                    return None
+
+                # Return results into the default ipython _ variable
+                return result
+
+        except (
+            ProgrammingError,
+            InternalError,
+            InterfaceError,
+            DatabaseError,
+            OperationalError,
+        ) as e:
+
+            # Normal syntax errors, missing table, etc. should come back as
+            # ProgrammingError. And the rest indicate something fundamentally
+            # broken at the DBAPI layer.
+            #
+            # BUT of course sqlite returns ALL errors as OperationalError. Sigh.
+
+            is_fatal = not isinstance(e, ProgrammingError) and not (
+                isinstance(e, OperationalError) and "sqlite" in str(e)
+            )
+
+            if not is_fatal:
+                if self.short_errors:
+                    print(e)
+                else:
+                    raise
+            else:
+                #
+                # Some sort of DBAPI-level error. Let's be conservative an err on the
+                # side of force-closing all of the engine's connections. This happens
+                # to Databricks if you leave the connection open and idle too long, but
+                # the existing connection is completely poisoned. We gots to
+                # dispose of the existing connection pool and make sure we get a brand
+                # new connection next time so that when the user does what users
+                # do in the face of errors (just hit the run button again), we want
+                # to try to give 'em a different experience the next go around.
+                #
+                # "Restart Kernel" is too big of a hammer here.
+                #
+                conn._engine.dispose()
+                conn._session = None
+                print(
+                    "Encoutered the following unexpected exception while trying to run the statement."
+                    " Closed the connection just to be safe. Re-run the cell to try again!\n\n"
+                )
+                raise
+
+    legal_sql_identifier = re.compile(r"^[A-Za-z0-9#_$]+")
+
+    def _persist_dataframe(self, raw, conn, user_ns, append=False):
+        """Implements PERSIST, which writes a DataFrame to the RDBMS"""
+        if not DataFrame:
+            raise ImportError("Must `pip install pandas` to use DataFrames")
+
+        frame_name = raw.strip(";")
+
+        # Get the DataFrame from the user namespace
+        if not frame_name:
+            raise SyntaxError("Syntax: %sql --persist <name_of_data_frame>")
+        try:
+            frame = eval(frame_name, user_ns)
+        except SyntaxError:
+            raise SyntaxError("Syntax: %sql --persist <name_of_data_frame>")
+        if not isinstance(frame, DataFrame) and not isinstance(frame, Series):
+            raise TypeError("%s is not a Pandas DataFrame or Series" % frame_name)
+
+        # Make a suitable name for the resulting database table
+        table_name = frame_name.lower()
+        table_name = self.legal_sql_identifier.search(table_name).group(0)
+
+        if_exists = "append" if append else "fail"
+        frame.to_sql(table_name, conn.session.engine, if_exists=if_exists)
+        return "Persisted %s" % table_name
+
+
+def load_ipython_extension(ip):
+    """Load the extension in IPython."""
+
+    # this fails in both Firefox and Chrome for OS X.
+    # I get the error: TypeError: IPython.CodeCell.config_defaults is undefined
+
+    # js = "IPython.CodeCell.config_defaults.highlight_modes['magic_sql'] = {'reg':[/^%%sql/]};"
+    ip.register_magics(SqlMagic)

--- a/noteable_magics/sql/parse.py
+++ b/noteable_magics/sql/parse.py
@@ -1,0 +1,88 @@
+import itertools
+import json
+import re
+import shlex
+from os.path import expandvars
+
+import six
+from six.moves import configparser as CP
+from sqlalchemy.engine.url import URL
+
+
+def connection_from_dsn_section(section, config):
+    parser = CP.ConfigParser()
+    parser.read(config.dsn_filename)
+    cfg_dict = dict(parser.items(section))
+    return str(URL.create(**cfg_dict))
+
+
+def _connection_string(s, config):
+
+    s = expandvars(s)  # for environment variables
+    if "@" in s or "://" in s:
+        return s
+    if s.startswith("[") and s.endswith("]"):
+        section = s.lstrip("[").rstrip("]")
+        parser = CP.ConfigParser()
+        parser.read(config.dsn_filename)
+        cfg_dict = dict(parser.items(section))
+        return str(URL.create(**cfg_dict))
+    return ""
+
+
+def parse(cell, config):
+    """Extract connection info and result variable from SQL
+    
+    Please don't add any more syntax requiring 
+    special parsing.  
+    Instead, add @arguments to SqlMagic.execute.
+    
+    We're grandfathering the 
+    connection string and `<<` operator in.
+    """
+
+    result = {"connection": "", "sql": "", "result_var": None}
+
+    pieces = cell.split(None, 3)
+    if not pieces:
+        return result
+    result["connection"] = _connection_string(pieces[0], config)
+    if result["connection"]:
+        pieces.pop(0)
+    if len(pieces) > 1 and pieces[1] == "<<":
+        result["result_var"] = pieces.pop(0)
+        pieces.pop(0)  # discard << operator
+    result["sql"] = (" ".join(pieces)).strip()
+    return result
+
+
+def _option_strings_from_parser(parser):
+    """Extracts the expected option strings (-a, --append, etc) from argparse parser 
+
+    Thanks Martijn Pieters
+    https://stackoverflow.com/questions/28881456/how-can-i-list-all-registered-arguments-from-an-argumentparser-instance
+
+    :param parser: [description]
+    :type parser: IPython.core.magic_arguments.MagicArgumentParser 
+    """
+    opts = [a.option_strings for a in parser._actions]
+    return list(itertools.chain.from_iterable(opts))
+
+
+def without_sql_comment(parser, line):
+    """Strips -- comment from a line 
+
+    The argparser unfortunately expects -- to precede an option, 
+    but in SQL that delineates a comment.  So this removes comments 
+    so a line can safely be fed to the argparser.
+
+    :param line: A line of SQL, possibly mixed with option strings 
+    :type line: str 
+    """
+
+    args = _option_strings_from_parser(parser)
+    result = itertools.takewhile(
+        lambda word: (not word.startswith("--")) or (word in args),
+        shlex.split(line, posix=False),
+    )
+    return " ".join(result)

--- a/noteable_magics/sql/run.py
+++ b/noteable_magics/sql/run.py
@@ -1,0 +1,415 @@
+import codecs
+import csv
+import operator
+import os.path
+import re
+from functools import reduce
+
+import prettytable
+import six
+import sqlalchemy
+import sqlparse
+
+from noteable_magics.sql.column_guesser import ColumnGuesserMixin
+
+try:
+    from pgspecial.main import PGSpecial
+except ImportError:
+    PGSpecial = None
+
+
+def unduplicate_field_names(field_names):
+    """Append a number to duplicate field names to make them unique."""
+    res = []
+    for k in field_names:
+        if k in res:
+            i = 1
+            while k + "_" + str(i) in res:
+                i += 1
+            k += "_" + str(i)
+        res.append(k)
+    return res
+
+
+class UnicodeWriter(object):
+    """
+    A CSV writer which will write rows to CSV file "f",
+    which is encoded in the given encoding.
+    """
+
+    def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
+        # Redirect output to a queue
+        self.queue = six.StringIO()
+        self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
+        self.stream = f
+        self.encoder = codecs.getincrementalencoder(encoding)()
+
+    def writerow(self, row):
+        if six.PY2:
+            _row = [s.encode("utf-8") if hasattr(s, "encode") else s for s in row]
+        else:
+            _row = row
+        self.writer.writerow(_row)
+        # Fetch UTF-8 output from the queue ...
+        data = self.queue.getvalue()
+        if six.PY2:
+            data = data.decode("utf-8")
+            # ... and reencode it into the target encoding
+            data = self.encoder.encode(data)
+        # write to the target stream
+        self.stream.write(data)
+        # empty queue
+        self.queue.truncate(0)
+        self.queue.seek(0)
+
+    def writerows(self, rows):
+        for row in rows:
+            self.writerow(row)
+
+
+class CsvResultDescriptor(object):
+    """Provides IPython Notebook-friendly output for the feedback after a ``.csv`` called."""
+
+    def __init__(self, file_path):
+        self.file_path = file_path
+
+    def __repr__(self):
+        return "CSV results at %s" % os.path.join(os.path.abspath("."), self.file_path)
+
+    def _repr_html_(self):
+        return '<a href="%s">CSV results</a>' % os.path.join(".", "files", self.file_path)
+
+
+def _nonbreaking_spaces(match_obj):
+    """
+    Make spaces visible in HTML by replacing all `` `` with ``&nbsp;``
+
+    Call with a ``re`` match object.  Retain group 1, replace group 2
+    with nonbreaking speaces.
+    """
+    spaces = "&nbsp;" * len(match_obj.group(2))
+    return "%s%s" % (match_obj.group(1), spaces)
+
+
+_cell_with_spaces_pattern = re.compile(r"(<td>)( {2,})")
+
+
+class ResultSet(list, ColumnGuesserMixin):
+    """
+    Results of a SQL query.
+
+    Can access rows listwise, or by string value of leftmost column.
+    """
+
+    def __init__(self, sqlaproxy, sql, config):
+        self.keys = sqlaproxy.keys()
+        self.sql = sql
+        self.config = config
+        self.limit = config.autolimit
+        style_name = config.style
+        self.style = prettytable.__dict__[style_name.upper()]
+        if sqlaproxy.returns_rows:
+            if self.limit:
+                list.__init__(self, sqlaproxy.fetchmany(size=self.limit))
+            else:
+                list.__init__(self, sqlaproxy.fetchall())
+            self.field_names = unduplicate_field_names(self.keys)
+            self.pretty = PrettyTable(self.field_names, style=self.style)
+            # self.pretty.set_style(self.style)
+        else:
+            list.__init__(self, [])
+            self.pretty = None
+
+    def _repr_html_(self):
+        _cell_with_spaces_pattern = re.compile(r"(<td>)( {2,})")
+        if self.pretty:
+            self.pretty.add_rows(self)
+            result = self.pretty.get_html_string()
+            result = _cell_with_spaces_pattern.sub(_nonbreaking_spaces, result)
+            if self.config.displaylimit and len(self) > self.config.displaylimit:
+                result = (
+                    '%s\n<span style="font-style:italic;text-align:center;">%d rows, truncated to displaylimit of %d</span>'
+                    % (result, len(self), self.config.displaylimit)
+                )
+            return result
+        else:
+            return None
+
+    def __str__(self, *arg, **kwarg):
+        self.pretty.add_rows(self)
+        return str(self.pretty or "")
+
+    def __getitem__(self, key):
+        """
+        Access by integer (row position within result set)
+        or by string (value of leftmost column)
+        """
+        try:
+            return list.__getitem__(self, key)
+        except TypeError:
+            result = [row for row in self if row[0] == key]
+            if not result:
+                raise KeyError(key)
+            if len(result) > 1:
+                raise KeyError('%d results for "%s"' % (len(result), key))
+            return result[0]
+
+    def dict(self):
+        """Returns a single dict built from the result set
+
+        Keys are column names; values are a tuple"""
+        return dict(zip(self.keys, zip(*self)))
+
+    def dicts(self):
+        "Iterator yielding a dict for each row"
+        for row in self:
+            yield dict(zip(self.keys, row))
+
+    def DataFrame(self):
+        "Returns a Pandas DataFrame instance built from the result set."
+        import pandas as pd
+
+        frame = pd.DataFrame(self, columns=(self and self.keys) or [])
+        return frame
+
+    def pie(self, key_word_sep=" ", title=None, **kwargs):
+        """Generates a pylab pie chart from the result set.
+
+        ``matplotlib`` must be installed, and in an
+        IPython Notebook, inlining must be on::
+
+            %%matplotlib inline
+
+        Values (pie slice sizes) are taken from the
+        rightmost column (numerical values required).
+        All other columns are used to label the pie slices.
+
+        Parameters
+        ----------
+        key_word_sep: string used to separate column values
+                      from each other in pie labels
+        title: Plot title, defaults to name of value column
+
+        Any additional keyword arguments will be passsed
+        through to ``matplotlib.pylab.pie``.
+        """
+        self.guess_pie_columns(xlabel_sep=key_word_sep)
+        import matplotlib.pylab as plt
+
+        pie = plt.pie(self.ys[0], labels=self.xlabels, **kwargs)
+        plt.title(title or self.ys[0].name)
+        return pie
+
+    def plot(self, title=None, **kwargs):
+        """Generates a pylab plot from the result set.
+
+        ``matplotlib`` must be installed, and in an
+        IPython Notebook, inlining must be on::
+
+            %%matplotlib inline
+
+        The first and last columns are taken as the X and Y
+        values.  Any columns between are ignored.
+
+        Parameters
+        ----------
+        title: Plot title, defaults to names of Y value columns
+
+        Any additional keyword arguments will be passsed
+        through to ``matplotlib.pylab.plot``.
+        """
+        import matplotlib.pylab as plt
+
+        self.guess_plot_columns()
+        self.x = self.x or range(len(self.ys[0]))
+        coords = reduce(operator.add, [(self.x, y) for y in self.ys])
+        plot = plt.plot(*coords, **kwargs)
+        if hasattr(self.x, "name"):
+            plt.xlabel(self.x.name)
+        ylabel = ", ".join(y.name for y in self.ys)
+        plt.title(title or ylabel)
+        plt.ylabel(ylabel)
+        return plot
+
+    def bar(self, key_word_sep=" ", title=None, **kwargs):
+        """Generates a pylab bar plot from the result set.
+
+        ``matplotlib`` must be installed, and in an
+        IPython Notebook, inlining must be on::
+
+            %%matplotlib inline
+
+        The last quantitative column is taken as the Y values;
+        all other columns are combined to label the X axis.
+
+        Parameters
+        ----------
+        title: Plot title, defaults to names of Y value columns
+        key_word_sep: string used to separate column values
+                      from each other in labels
+
+        Any additional keyword arguments will be passsed
+        through to ``matplotlib.pylab.bar``.
+        """
+        import matplotlib.pylab as plt
+
+        self.guess_pie_columns(xlabel_sep=key_word_sep)
+        plot = plt.bar(range(len(self.ys[0])), self.ys[0], **kwargs)
+        if self.xlabels:
+            plt.xticks(range(len(self.xlabels)), self.xlabels, rotation=45)
+        plt.xlabel(self.xlabel)
+        plt.ylabel(self.ys[0].name)
+        return plot
+
+    def csv(self, filename=None, **format_params):
+        """Generate results in comma-separated form.  Write to ``filename`` if given.
+        Any other parameters will be passed on to csv.writer."""
+        if not self.pretty:
+            return None  # no results
+        self.pretty.add_rows(self)
+        if filename:
+            encoding = format_params.get("encoding", "utf-8")
+            if six.PY2:
+                outfile = open(filename, "wb")
+            else:
+                outfile = open(filename, "w", newline="", encoding=encoding)
+        else:
+            outfile = six.StringIO()
+        writer = UnicodeWriter(outfile, **format_params)
+        writer.writerow(self.field_names)
+        for row in self:
+            writer.writerow(row)
+        if filename:
+            outfile.close()
+            return CsvResultDescriptor(filename)
+        else:
+            return outfile.getvalue()
+
+
+def interpret_rowcount(rowcount):
+    if rowcount < 0:
+        result = "Done."
+    else:
+        result = "%d rows affected." % rowcount
+    return result
+
+
+class FakeResultProxy(object):
+    """A fake class that pretends to behave like the ResultProxy from
+    SqlAlchemy.
+    """
+
+    def __init__(self, cursor, headers):
+        if cursor is None:
+            cursor = []
+            headers = []
+        if isinstance(cursor, list):
+            self.from_list(source_list=cursor)
+        else:
+            self.fetchall = cursor.fetchall
+            self.fetchmany = cursor.fetchmany
+            self.rowcount = cursor.rowcount
+        self.keys = lambda: headers
+        self.returns_rows = True
+
+    def from_list(self, source_list):
+        "Simulates SQLA ResultProxy from a list."
+
+        self.fetchall = lambda: source_list
+        self.rowcount = len(source_list)
+
+        def fetchmany(size):
+            pos = 0
+            while pos < len(source_list):
+                yield source_list[pos : pos + size]
+                pos += size
+
+        self.fetchmany = fetchmany
+
+
+# some dialects have autocommit
+# specific dialects break when commit is used:
+_COMMIT_BLACKLIST_DIALECTS = {
+    "athena",
+    "clickhouse",
+    "ingres",
+    "mssql",
+    "teradata",
+    "vertica",
+}
+
+
+def add_commit_blacklist_dialect(dialect: str):
+    """Add a dialect to the blacklist of dialects that do not support commit."""
+
+    if "+" in dialect:
+        raise ValueError("Dialects do not have '+' inside (thats a dialect+driver combo)")
+
+    _COMMIT_BLACKLIST_DIALECTS.add(dialect)
+
+
+def _commit(conn, config):
+    """Issues a commit, if appropriate for current config and dialect"""
+
+    _should_commit = config.autocommit and all(
+        dialect not in str(conn.dialect) for dialect in _COMMIT_BLACKLIST_DIALECTS
+    )
+
+    if _should_commit:
+        try:
+            conn.session.execute("commit")
+        except sqlalchemy.exc.OperationalError:
+            pass  # not all engines can commit
+
+
+def run(conn, sql, config, user_namespace):
+    if sql.strip():
+        for statement in sqlparse.split(sql):
+            first_word = sql.strip().split()[0].lower()
+            if first_word == "begin":
+                raise Exception("ipython_sql does not support transactions")
+            if first_word.startswith("\\") and (
+                "postgres" in str(conn.dialect) or "redshift" in str(conn.dialect)
+            ):
+                if not PGSpecial:
+                    raise ImportError("pgspecial not installed")
+                pgspecial = PGSpecial()
+                _, cur, headers, _ = pgspecial.execute(conn.session.connection.cursor(), statement)[
+                    0
+                ]
+                result = FakeResultProxy(cur, headers)
+            else:
+                txt = sqlalchemy.sql.text(statement)
+                result = conn.session.execute(txt, user_namespace)
+            _commit(conn=conn, config=config)
+            if result and config.feedback:
+                print(interpret_rowcount(result.rowcount))
+        resultset = ResultSet(result, statement, config)
+        if config.autopandas:
+            return resultset.DataFrame()
+        else:
+            return resultset
+        # returning only last result, intentionally
+    else:
+        return "Connected: %s" % conn.name
+
+
+class PrettyTable(prettytable.PrettyTable):
+    def __init__(self, *args, **kwargs):
+        self.row_count = 0
+        self.displaylimit = None
+        return super(PrettyTable, self).__init__(*args, **kwargs)
+
+    def add_rows(self, data):
+        if self.row_count and (data.config.displaylimit == self.displaylimit):
+            return  # correct number of rows already present
+        self.clear_rows()
+        self.displaylimit = data.config.displaylimit
+        if self.displaylimit == 0:
+            self.displaylimit = None  # TODO: remove this to make 0 really 0
+        if self.displaylimit in (None, 0):
+            self.row_count = len(data)
+        else:
+            self.row_count = min(len(data), self.displaylimit)
+        for row in data[: self.displaylimit]:
+            self.add_row(row)

--- a/poetry.lock
+++ b/poetry.lock
@@ -495,32 +495,9 @@ test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipyk
 name = "ipython-genutils"
 version = "0.2.0"
 description = "Vestigial utilities from IPython"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
-
-[[package]]
-name = "ipython-sql-noteable"
-version = "0.4.1"
-description = ""
-category = "main"
-optional = false
-python-versions = "*"
-develop = false
-
-[package.dependencies]
-ipython = ">=1.0"
-ipython-genutils = ">=0.1.0"
-prettytable = "<1"
-six = "*"
-sqlalchemy = ">=0.6.7"
-sqlparse = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/noteable-io/ipython-sql-noteable.git"
-reference = "08d8d9cc8785b3cee5cd210fa58c01d8391d38e2"
-resolved_reference = "08d8d9cc8785b3cee5cd210fa58c01d8391d38e2"
 
 [[package]]
 name = "isort"
@@ -899,11 +876,17 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prettytable"
-version = "0.7.2"
-description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format."
+version = "3.3.0"
+description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
+
+[package.dependencies]
+wcwidth = "*"
+
+[package.extras]
+tests = ["pytest", "pytest-cov", "pytest-lazy-fixture"]
 
 [[package]]
 name = "prometheus-client"
@@ -1465,7 +1448,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "995191949415fb8aabd1cea005fd31a0f100a5e09a335f98e18b25b105d334e5"
+content-hash = "5abaaa33721c82df16b836d5f250c0f2487fe1fd481f9485791ea5d49337af85"
 
 [metadata.files]
 anyio = [
@@ -1813,7 +1796,6 @@ ipython-genutils = [
     {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
     {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
 ]
-ipython-sql-noteable = []
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
     {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
@@ -1974,11 +1956,7 @@ pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
-prettytable = [
-    {file = "prettytable-0.7.2.tar.bz2", hash = "sha256:853c116513625c738dc3ce1aee148b5b5757a86727e67eff6502c7ca59d43c36"},
-    {file = "prettytable-0.7.2.tar.gz", hash = "sha256:2d5460dc9db74a32bcc8f9f67de68b2c4f4d2f01fa3bd518764c69156d9cacd9"},
-    {file = "prettytable-0.7.2.zip", hash = "sha256:a53da3b43d7a5c229b5e3ca2892ef982c46b7923b51e98f0db49956531211c4f"},
-]
+prettytable = []
 prometheus-client = [
     {file = "prometheus_client-0.14.1-py3-none-any.whl", hash = "sha256:522fded625282822a89e2773452f42df14b5a8e84a86433e3f8a189c1d54dc01"},
     {file = "prometheus_client-0.14.1.tar.gz", hash = "sha256:5459c427624961076277fdc6dc50540e2bacb98eebde99886e59ec55ed92093a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ backoff = "^1.10.0"
 click = "^8.0.4" # pinned until black is updated to not use internal module that was removed by click in 8.1.0; https://github.com/psf/black/issues/2964
 httpx = {extras = ["http2"], version = "^0.18.2"}
 ipython = "^7.31.1"
-ipython-sql-noteable = { git= "https://github.com/noteable-io/ipython-sql-noteable.git", rev="08d8d9cc8785b3cee5cd210fa58c01d8391d38e2"}
 openpyxl = "^3.0.7"
 pandas = "^1.2.1"
 pyarrow = "^6.0.1" # Snowflake driver wants 6.0.X series as of June 2022.
@@ -21,6 +20,9 @@ structlog = "^21.1.0"
 unidiff = "^0.6.0"
 xlrd = "^2.0.1"
 numpy = "^1.22.2"
+prettytable = "^3.3.0"
+SQLAlchemy = "^1.4.39"
+sqlparse = "^0.4.2"
 
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 
 import pytest
-from sql.connection import Connection
 from sqlalchemy import text
 
 from noteable_magics import LOCAL_DB_CONN_HANDLE, NoteableDataLoaderMagic, get_db_connection
+from noteable_magics.sql.connection import Connection
 
 
 @pytest.fixture

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -8,10 +8,10 @@ from uuid import uuid4
 
 import pkg_resources
 import pytest
-from sql.connection import Connection
-from sql.run import _COMMIT_BLACKLIST_DIALECTS
 
 from noteable_magics import datasource_postprocessing, datasources
+from noteable_magics.sql.connection import Connection
+from noteable_magics.sql.run import _COMMIT_BLACKLIST_DIALECTS
 
 
 @pytest.fixture


### PR DESCRIPTION
... as of commit 08d8d9cc8785b3cee5cd210fa58c01d8391d38e2 into noteable_magics as sub-package sql.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Wholly digest our ipython-sql-noteable directly into noteable-notebook-magics, so that there's one fewer repo and set of rebuilds and tags to manage.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Whenever breathing on anything in ipython-sql-noteable, then have to also update git tags here in noteable-notebook-magics, two places in polymorph, then also in expel's kernel build. Since those changes also tend to go hand-in-hand with changes here in the datasources portion of noteable-notebook-magics, and also that noteable-notebook-magics also has a test suite that exercises at least some portion of ipyhton-sql and actually gets run at build time, this is both simpler and better?

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- external package sql.* becomes noteable_magics.sql.* .
