### PR TITLE
RTU log level in PA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `%ntbl change-log-level --rtu-level DEBUG` will update relevant Sending, PA, and Origami libraries to render useful debug logs related to RTU processing in PA
+
+### Changed
+- `%ntbl change-log-level` no longer requires `--app-level` arg. If it's not passed in, it won't change PA `planar_ally.*` log level from wherever it's currently set
 
 ## [2.0.0] - 2022-03-15
 ### Changed

--- a/noteable_magics/ntbl.py
+++ b/noteable_magics/ntbl.py
@@ -106,7 +106,7 @@ def ntbl_magic():
 @click.pass_obj
 def change_log_level(obj: ContextObject, app_level, ext_level, rtu_level):
     obj.planar_ally.change_log_level(
-        app_log_level=app_level, ext_log_level=ext_level, rtu_level=rtu_level
+        app_log_level=app_level, ext_log_level=ext_level, rtu_log_level=rtu_level
     )
 
 

--- a/noteable_magics/ntbl.py
+++ b/noteable_magics/ntbl.py
@@ -100,8 +100,9 @@ def ntbl_magic():
 
 
 @ntbl_magic.command(help="Change planar-ally log level", cls=NTBLCommand, hidden=True)
-@click.option("--app-level", help="New application log level", required=True, type=click.STRING)
+@click.option("--app-level", help="New application log level", required=False, type=click.STRING)
 @click.option("--ext-level", help="New external log level", required=False, type=click.STRING)
+@click.option('--rtu-level', help="Set RTU-related log level", required=False, type=click.STRING)
 @click.pass_obj
 def change_log_level(obj: ContextObject, app_level, ext_level):
     obj.planar_ally.change_log_level(app_log_level=app_level, ext_log_level=ext_level)

--- a/noteable_magics/ntbl.py
+++ b/noteable_magics/ntbl.py
@@ -104,8 +104,10 @@ def ntbl_magic():
 @click.option("--ext-level", help="New external log level", required=False, type=click.STRING)
 @click.option('--rtu-level', help="Set RTU-related log level", required=False, type=click.STRING)
 @click.pass_obj
-def change_log_level(obj: ContextObject, app_level, ext_level):
-    obj.planar_ally.change_log_level(app_log_level=app_level, ext_log_level=ext_level)
+def change_log_level(obj: ContextObject, app_level, ext_level, rtu_level):
+    obj.planar_ally.change_log_level(
+        app_log_level=app_level, ext_log_level=ext_level, rtu_level=rtu_level
+    )
 
 
 @ntbl_magic.group(help="Push local updates to a remote store")

--- a/noteable_magics/planar_ally_client/api.py
+++ b/noteable_magics/planar_ally_client/api.py
@@ -40,13 +40,19 @@ class PlanarAllyAPI:
     def dataset_fs(self) -> "DatasetFileSystemAPI":
         return DatasetFileSystemAPI(self, FileKind.dataset)
 
-    def change_log_level(self, app_log_level: str, ext_log_level: Optional[str] = None) -> None:
+    def change_log_level(
+        self,
+        app_log_level: Optional[str] = None,
+        ext_log_level: Optional[str] = None,
+        rtu_log_level: Optional[str] = None,
+    ) -> None:
         self.post(
             "logs",
             "change log level",
             json={
                 "new_app_level": app_log_level,
                 "new_ext_level": ext_log_level,
+                'rtu_level': rtu_log_level,
             },
             base_url=f"{self._base_url}/instance/",
         )

--- a/noteable_magics/planar_ally_client/api.py
+++ b/noteable_magics/planar_ally_client/api.py
@@ -52,7 +52,7 @@ class PlanarAllyAPI:
             json={
                 "new_app_level": app_log_level,
                 "new_ext_level": ext_log_level,
-                'rtu_level': rtu_log_level,
+                "rtu_log_level": rtu_log_level,
             },
             base_url=f"{self._base_url}/instance/",
         )

--- a/tests/planar_ally_client/test_api.py
+++ b/tests/planar_ally_client/test_api.py
@@ -131,6 +131,6 @@ def test_change_log_level(api, mock_no_content, ext_level):
         mock_request.assert_called_with(
             'POST',
             'http://localhost:7000/instance/logs',
-            json={'new_app_level': 'DEBUG', 'new_ext_level': ext_level},
+            json={'new_app_level': 'DEBUG', 'new_ext_level': ext_level, 'rtu_log_level': None},
             timeout=Timeout(connect=0.5, read=60.0, write=60.0, pool=60.0),
         )

--- a/tests/test_ntbl.py
+++ b/tests/test_ntbl.py
@@ -85,4 +85,6 @@ def test_change_log_level(runner, context):
     ) as change_mock:
         result = runner.invoke(change_log_level, ["--app-level", "DEBUG"], obj=context)
         assert result.exit_code == 0, ''.join(traceback.format_exception(*result.exc_info))
-        change_mock.assert_called_with(app_log_level="DEBUG", ext_log_level=None)
+        change_mock.assert_called_with(
+            app_log_level="DEBUG", ext_log_level=None, rtu_log_level=None
+        )


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Unit tests are present
- [x] Have you validated this change locally?

## Summary of Changes

Adds new feature `%ntbl change-log-level --rtu-level DEBUG` to enable debug logs for RTU-specific library/code sections (as defined in PA code)

Makes `--app-level` optional in `change-log-level` command. If it's omitted, then PA `planar_ally.*` logs will revert to default PA level (INFO).


Loom video of feature in action: https://www.loom.com/share/cfa6e9c6800b4d0095c1d8fd8d1e8830

PA PR that needs to get merged before this goes online: https://github.com/noteable-io/planar-ally/pull/235
