### PR TITLE
Have sqlmagic return the dataframe while also assigning to named vari…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `%ntbl change-log-level` no longer requires `--app-level` arg. If it's not passed in, it won't change PA `planar_ally.*` log level from wherever it's currently set
-- `@noteable` magic changed to use duckdb
+- `@noteable` magic changed to use duckdb, away from sqlite.
+- `%%sql @e456456 my_df << select a, b, c from foo` variable assignment syntax will now always return the resulting dataframe as well as silently assign to the interpreter variable (`my_df` in this case) as side-effect. Previously would only assign to the interpreter variable and announce the fact with a print(), while having no return result.
 
 ## [2.0.0] - 2022-03-15
 ### Changed

--- a/noteable_magics/datasource_postprocessing.py
+++ b/noteable_magics/datasource_postprocessing.py
@@ -58,8 +58,8 @@ def postprocess_postgresql(
     # extra behavior into the driver as side-effect so that interrupting the
     # kernel does what we expect.
 
-    import psycopg2.extras
     import psycopg2.extensions
+    import psycopg2.extras
 
     psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)
 

--- a/noteable_magics/sql/connection.py
+++ b/noteable_magics/sql/connection.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import sqlalchemy
 from sqlalchemy.engine import Engine
+import sqlalchemy.engine.base
 
 
 class ConnectionError(Exception):
@@ -91,11 +92,16 @@ class Connection(object):
         Connection.current = self
 
     @property
-    def session(self):
-        """Lazily connect to the database."""
+    def session(self) -> sqlalchemy.engine.base.Connection:
+        """Lazily connect to the database.
+
+        Despite the name, this is a SQLA Connection, not a Session. And 'Connection'
+        is highly overused term around here.
+        """
 
         if not self._session:
             self._session = self._engine.connect()
+
         return self._session
 
     @classmethod

--- a/noteable_magics/sql/connection.py
+++ b/noteable_magics/sql/connection.py
@@ -2,8 +2,8 @@ import os
 from typing import Optional
 
 import sqlalchemy
-from sqlalchemy.engine import Engine
 import sqlalchemy.engine.base
+from sqlalchemy.engine import Engine
 
 
 class ConnectionError(Exception):

--- a/noteable_magics/sql/magic.py
+++ b/noteable_magics/sql/magic.py
@@ -234,14 +234,11 @@ class SqlMagic(Magics, Configurable):
 
                 return None
             else:
-
                 if parsed["result_var"]:
-                    result_var = parsed["result_var"]
-                    print("Returning data to local variable {}".format(result_var))
-                    self.shell.user_ns.update({result_var: result})
-                    return None
+                    # Silently assign the result to this named variable, ENG-4711.
+                    self.shell.user_ns.update({parsed["result_var"]: result})
 
-                # Return results into the default ipython _ variable
+                # Always return query results into the default ipython _ variable
                 return result
 
         except (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,3 +84,22 @@ def with_empty_connections():
     yield
 
     Connection.connections = preexisting_connections
+
+
+@pytest.fixture
+def foo_database_connection(with_empty_connections):
+    """Make an @foo SQLite connection to simulate a non-default bootstrapped datasource."""
+
+    handle = '@foo'
+    human_name = "My Shiny Connection"
+    Connection.set("sqlite:///:memory:", displaycon=False, name=handle, human_name=human_name)
+
+    yield handle, human_name
+
+
+@pytest.fixture
+def populated_foo_database(foo_database_connection):
+    connection = Connection.connections['@foo']
+    db = connection.session  # sic, a sqlalchemy.engine.base.Connection, not a Session. Sigh.
+    db.execute('create table int_table(a int, b int, c int)')
+    db.execute('insert into int_table (a, b, c) values (1, 2, 3), (4, 5, 6)')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from noteable_magics.planar_ally_client.types import (
     FileProgressUpdateContent,
     FileProgressUpdateMessage,
 )
+from noteable_magics.sql.connection import Connection
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -71,3 +72,15 @@ def mock_dataset_stream():
         ).json(),
         200,
     ).stream()
+
+
+@pytest.fixture
+def with_empty_connections():
+    """Empty out the current set of sql magic Connections"""
+    preexisting_connections = Connection.connections
+
+    Connection.connections = {}
+
+    yield
+
+    Connection.connections = preexisting_connections

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -1,0 +1,60 @@
+""" Tests over the data loading magic, "create_or_replace_data_view" """
+
+
+import pytest
+import pandas as pd
+
+from noteable_magics.sql.connection import Connection
+from noteable_magics.sql.magic import SqlMagic
+
+from IPython.core.interactiveshell import InteractiveShell
+
+
+@pytest.fixture
+def ipython_shell() -> InteractiveShell:
+    return InteractiveShell()
+
+
+@pytest.fixture
+def sql_magic(ipython_shell) -> SqlMagic:
+    magic = SqlMagic(ipython_shell)
+    # As would be done when we normally bootstrap things ...
+    magic.autopandas = True
+
+    return magic
+
+
+@pytest.fixture
+def foo_database_connection(with_empty_connections):
+    """Make an @foo SQLite connection to simulate a non-default bootstrapped datasource."""
+
+    handle = '@foo'
+    human_name = "My Shiny Connection"
+    Connection.set("sqlite:///:memory:", displaycon=False, name=handle, human_name=human_name)
+
+    yield handle, human_name
+
+
+@pytest.fixture
+def populated_foo_database(foo_database_connection):
+    connection = Connection.connections['@foo']
+    db = connection.session  # sic, a sqlalchemy.engine.base.Connection, not a Session. Sigh.
+    db.execute('create table int_table(a int, b int, c int)')
+    db.execute('insert into int_table (a, b, c) values (1, 2, 3), (4, 5, 6)')
+
+
+@pytest.mark.usefixtures("populated_foo_database")
+class TestSqlMagic:
+    def test_assigment_to_variable(self, sql_magic, ipython_shell):
+        """Test that when the 'varname << select ...' syntax is used, the df is returned
+        as the main execute result, and varname is side-effect assigned to."""
+
+        results = sql_magic.execute('@foo my_df << select a from int_table')
+        assert isinstance(results, pd.DataFrame)
+
+        # Two rows as from populated_foo_database
+        assert len(results) == 2
+        assert results['a'].tolist() == [1, 4]
+
+        # Should have also assigned the results to global 'my_df' in the ipython shell.
+        assert ipython_shell.user_ns['my_df'] is results

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -44,6 +44,17 @@ def populated_foo_database(foo_database_connection):
 
 @pytest.mark.usefixtures("populated_foo_database")
 class TestSqlMagic:
+    def test_basic_query(self, sql_magic, ipython_shell):
+        """Test basic query behavior"""
+
+        results = sql_magic.execute('@foo select a, b from int_table')
+        assert isinstance(results, pd.DataFrame)
+
+        # Two rows as from populated_foo_database
+        assert len(results) == 2
+        assert results['a'].tolist() == [1, 4]
+        assert results['b'].tolist() == [2, 5]
+
     def test_assigment_to_variable(self, sql_magic, ipython_shell):
         """Test that when the 'varname << select ...' syntax is used, the df is returned
         as the main execute result, and varname is side-effect assigned to."""

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -1,13 +1,12 @@
 """ Tests over the data loading magic, "create_or_replace_data_view" """
 
 
-import pytest
 import pandas as pd
+import pytest
+from IPython.core.interactiveshell import InteractiveShell
 
 from noteable_magics.sql.connection import Connection
 from noteable_magics.sql.magic import SqlMagic
-
-from IPython.core.interactiveshell import InteractiveShell
 
 
 @pytest.fixture


### PR DESCRIPTION
…able as side effect.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- `%%sql @e456456 my_df << select a, b, c from foo` variable assignment syntax will now always return the resulting dataframe as well as silently assign to the interpreter variable (`my_df` in this case) as side-effect. Previously would only assign to the interpreter variable and announce the fact with a print(), while having no return result.
- Now got framework to actually test the sql magic, plus a couple tests.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Would only assign to the interpreter variable and announce the fact with a print(), while having no return result.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->
- When using the "varname << select ..." syntax:
  * No more print.
  * Returns the query result as the direct cell result, always accessible as '_'
  * Will side-effect also cause the variable name to be assigned to.
