### PR TITLE
Simpler, more end-user oriented message if an unknown datasource... 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@noteable` magic changed to use duckdb, away from sqlite.
 - `%%sql @e456456 my_df << select a, b, c from foo` variable assignment syntax will now always return the resulting dataframe as well as silently assign to the interpreter variable (`my_df` in this case) as side-effect. Previously would only assign to the interpreter variable and announce the fact with a print(), while having no return result.
 - Now use jinjasql for SQL cell template expansion, not simple string.Template.
+- Simpler message printed as the cell's side-effect if an unknown datasource handle is attempted.
 
 ## [2.0.0] - 2022-03-15
 ### Changed

--- a/noteable_magics/sql/connection.py
+++ b/noteable_magics/sql/connection.py
@@ -90,7 +90,7 @@ class Connection(object):
                 # Is indeed the above most likely reason. Cell ran something like "%sql @3244356456 select true",
                 # and magic.py's call to `conn = noteable_magics.sql.connection.Connection.set(...)`
                 # ended up here trying to create a new Connection and Engine because '@3244356456' didn't
-                # rendezvous with an already knoen bootstrapped datasource from vault via the startup-time bootstrapping
+                # rendezvous with an already known bootstrapped datasource from vault via the startup-time bootstrapping
                 # noteable_magics.datasources.bootstrap_datasources() call. Most likely reason for that is because
                 # the user created the datasource _after_ when the kernel was launched and other checks and balances
                 # didn't prevent them from trying to gesture to use it in this kernel session.

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -92,7 +92,6 @@ class TestSqlMagic:
 
         # sql magic invocation of an unknown connection will end up calling .set() with
         # that unknown connection's handle. Should raise. (This is unit-test-y)
-
         # Verbiage from ENG-4264.
         expected_message = "Cannot find data connection. If you recently created this connection, please restart the kernel."
 


### PR DESCRIPTION
... is attempted to be used.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- If an unknown datasource is attempted to be used (say, `%sql @45656745 select true`, when  `@45656745` was not present at bootstrapping time most likely because the datasource was created after when the kernel was launched, print as cell's output "Cannot find data connection. If you recently created this connection, please restart the kernel." per ENG-4264.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Get a really unhelpful message, printed twice, sandwitching an underlying SQLA exception when trying to create a new Engine with way not enough info:
`Connection info needed in SQLAlchemy format, example: postgresql://username:password@hostname/dbname or an existing connection: dict_keys(['@0b2c5a31da854e49ad534a55a7788925', '@noteable']) Could not parse rfc1738 URL from string '@4d199317d9a145b892c7ddc2f1becd65' Connection info needed in SQLAlchemy format, example: postgresql://username:password@hostname/dbname or an existing connection: dict_keys(['@0b2c5a31da854e49ad534a55a7788925', '@noteable'])`

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Just says, once, "Cannot find data connection. If you recently created this connection, please restart the kernel." 
