### PR TITLE
Add sqlalchemy-cockroachdb dependency, add in simple test over CRDB d…

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1910,6 +1910,17 @@ geography = ["geoalchemy2", "shapely"]
 tests = ["packaging", "pytz"]
 
 [[package]]
+name = "sqlalchemy-cockroachdb"
+version = "1.4.4"
+description = "CockroachDB dialect for SQLAlchemy"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+SQLAlchemy = "*"
+
+[[package]]
 name = "sqlalchemy-databricks"
 version = "0.2.0"
 description = "SQLAlchemy Dialect for Databricks"
@@ -2190,7 +2201,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "8dda347e49c3e3f51286fc287c51a1a39177ff59c5cb9c26f67ce5d270d63c4a"
+content-hash = "5ea950eeac17d698c9c935161f146a43dc4f5befc4ffb1fdfc63b5cb9e979e8e"
 
 [metadata.files]
 anyio = [
@@ -2823,6 +2834,7 @@ soupsieve = [
 ]
 sqlalchemy = []
 sqlalchemy-bigquery = []
+sqlalchemy-cockroachdb = []
 sqlalchemy-databricks = []
 sqlalchemy-redshift = []
 sqlparse = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ sqlalchemy-bigquery = {version = "1.4.4", python = ">=3.8,<3.11"}
 sqlalchemy-databricks = {version = "0.2.0"}
 trino = {version = "0.313.0", extras = ["sqlalchemy"]}
 greenlet = "^1.1.3"
+sqlalchemy-cockroachdb = "^1.4.4"
 
 
 

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -97,7 +97,7 @@ class SampleData:
         'simple-cockroachdb': DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['sqlalchemy-cockroachdb', 'psycopg2-binary'],
-                'allow_datasource_dialect_autoinstall': True,
+                'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'cockroachdb',
                 'sqlmagic_autocommit': False,
                 'name': 'My CRDB',
@@ -113,7 +113,7 @@ class SampleData:
         'simple-postgres': DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['psycopg2-binary'],
-                'allow_datasource_dialect_autoinstall': True,
+                'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'postgresql',
                 'sqlmagic_autocommit': True,
                 'name': 'My PostgreSQL',
@@ -129,7 +129,7 @@ class SampleData:
         'postgres-require-ssl': DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['psycopg2-binary'],
-                'allow_datasource_dialect_autoinstall': True,
+                'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'postgresql',
                 'sqlmagic_autocommit': True,
                 'name': 'My PostgreSQL SSL',
@@ -163,7 +163,7 @@ class SampleData:
         'trino': DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['trino[sqlalchemy]'],
-                'allow_datasource_dialect_autoinstall': True,
+                'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'trino',
                 'sqlmagic_autocommit': False,  # This one is special!
                 # And explicitly no name assigned, 'legacy'.
@@ -178,7 +178,7 @@ class SampleData:
         'databricks': DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['sqlalchemy-databricks'],
-                'allow_datasource_dialect_autoinstall': True,
+                'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'databricks+connector',
                 'sqlmagic_autocommit': False,  # This one is special!
                 'name': 'My Databricks',
@@ -199,7 +199,7 @@ class SampleData:
         'snowflake-required': DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['snowflake-sqlalchemy'],
-                'allow_datasource_dialect_autoinstall': True,
+                'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'snowflake',
                 'sqlmagic_autocommit': True,
                 'name': 'My Snowflake',
@@ -216,7 +216,7 @@ class SampleData:
         'snowflake-with-database': DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['snowflake-sqlalchemy'],
-                'allow_datasource_dialect_autoinstall': True,
+                'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'snowflake',
                 'sqlmagic_autocommit': True,
                 'name': 'My Snowflake with database',
@@ -234,7 +234,7 @@ class SampleData:
         'snowflake-with-database-and-schema': DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['snowflake-sqlalchemy'],
-                'allow_datasource_dialect_autoinstall': True,
+                'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'snowflake',
                 'sqlmagic_autocommit': True,
                 'name': 'Snowflake with database and schema',
@@ -253,7 +253,7 @@ class SampleData:
         'snowflake-with-empty-db-and-schema': DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['snowflake-sqlalchemy'],
-                'allow_datasource_dialect_autoinstall': True,
+                'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'snowflake',
                 'sqlmagic_autocommit': True,
                 'name': 'Snowflake with empty db and schema',
@@ -371,7 +371,7 @@ class TestBootstrapDatasource:
         case_data = DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['sqlalchemy-bigquery'],
-                'allow_datasource_dialect_autoinstall': True,
+                'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'bigquery',
                 'sqlmagic_autocommit': True,
             },

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -94,6 +94,22 @@ class SampleData:
     """Test case fodder"""
 
     samples = {
+        'simple-cockroachdb': DatasourceJSONs(
+            meta_dict={
+                'required_python_modules': ['sqlalchemy-cockroachdb', 'psycopg2-binary'],
+                'allow_datasource_dialect_autoinstall': True,
+                'drivername': 'cockroachdb',
+                'sqlmagic_autocommit': False,
+                'name': 'My CRDB',
+            },
+            dsn_dict={
+                'username': 'scott',
+                'password': 'tiger',
+                'host': 'localhost',
+                'port': 26257,
+                'database': 'defaultdb',
+            },
+        ),
         'simple-postgres': DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['psycopg2-binary'],


### PR DESCRIPTION
…atasource type.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Install the CRDB SQLA dialect as a dependency. 'psycopg2-binary' was already a dependency via postgresql support.
- Remove asking for installation-on-the-fly in the test suite, in that all required drivers should now be installed implicitly via `pyproject.toml` entries. This leaves parts of the actual 'please do auto-install if requested' codepath uncovered at this time, but only James + Integration depends on this for when bootstrapping new datasource types on integration.
- This is how the datasource dialect + drivers make it into polymorph image(s) now: via transitive dependence on noteable-notebook-magic's dependencies.
