### PR TITLE
Metadata subcommand framework for SQL cells. Implement "\schemas" to …

### DIFF
--- a/noteable_magics/sql/connection.py
+++ b/noteable_magics/sql/connection.py
@@ -3,9 +3,8 @@ from typing import Optional, Union
 
 import sqlalchemy
 import sqlalchemy.engine.base
-from sqlalchemy.engine import Engine
 import structlog
-
+from sqlalchemy.engine import Engine
 
 logger = structlog.get_logger(__name__)
 

--- a/noteable_magics/sql/magic.py
+++ b/noteable_magics/sql/magic.py
@@ -14,10 +14,7 @@ from sqlalchemy.exc import (
 import noteable_magics.sql.connection
 import noteable_magics.sql.parse
 import noteable_magics.sql.run
-from noteable_magics.sql.meta_commands import (
-    MetaCommandException,
-    run_meta_command,
-)
+from noteable_magics.sql.meta_commands import MetaCommandException, run_meta_command
 
 try:
     from traitlets import Bool, Int, Unicode

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -65,7 +65,7 @@ class SchemasCommand(MetaCommand):
     invokers = ['\\schemas', '\\schemas+', '\\dn', '\\dn+']
     accepts_args = False
 
-    def run(self, invoked_as: str, args: list[str]):
+    def run(self, invoked_as: str, args: List[str]):
         insp = self.get_inspector()
 
         default_schema = insp.default_schema_name
@@ -95,7 +95,7 @@ class HelpCommand(MetaCommand):
     invokers = ['\\help']
     accepts_args = True
 
-    def run(self, invoked_as: str, args: list[str]):
+    def run(self, invoked_as: str, args: List[str]):
         # If no args, will return DF describing usage of all registered subcommands.
         # If run with exactly one subcommand, find it in registry and just talk about that one.
         # If subcommand not found, then complain.

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -1,0 +1,116 @@
+from typing import Optional
+
+from sqlalchemy import inspect
+from sqlalchemy.engine.reflection import Inspector
+
+from pandas import DataFrame
+
+from IPython.core.interactiveshell import InteractiveShell
+
+from noteable_magics.sql.connection import Connection
+
+__all__ = ['MetaCommandException', 'run_meta_command']
+
+
+class MetaCommandException(Exception):
+    """General exception when evaluating SQL cell meta commands"""
+
+    pass
+
+
+class MetaCommandInvocationException(MetaCommandException):
+    """Invoked a specific meta command incorrectly.
+
+    Will trigger sql-magic print() to suggest '\help \<subcommand>'
+    """
+
+    invoked_with: Optional[str] = None
+
+    def __init__(self, *args, invoked_with, **kwargs):
+        self.invoked_with = invoked_with
+        super().__init__(*args, **kwargs)
+
+
+class MetaCommand:
+    """Base class for family of metadata commands to do operations like schema-introspection, etc.
+    within SQL cells.
+    """
+
+    # List of strings that will invoke this subclass.
+    # Primary human-readable and memorable invocation string should come first, then any shorthand
+    # aliases. See how global _registry
+    invokers: list[str]
+
+    # Does this command accept additional arguments?
+    accepts_args: bool
+
+    def __init__(self, shell: InteractiveShell, conn: Connection):
+        self.shell = shell
+        self.conn = conn
+
+    def run(self, invoked_as: str, args: list[str]):
+        raise NotImplementedError
+
+    def get_inspector(self) -> Inspector:
+        return inspect(self.conn._engine)
+
+
+class SchemasCommand(MetaCommand):
+    """List all the schemas (namespaces for tables, views) within a database.
+
+    If invoked with trailing '+', will also include the count of tables and views
+    within each schema.
+    """
+
+    invokers = ['\\schemas', '\\schemas+', '\\dn', '\\dn+']
+    accepts_args = False
+
+    def run(self, invoked_as: str, args: list[str]):
+        insp = self.get_inspector()
+
+        default_schema = insp.default_schema_name
+        all_schemas = sorted(insp.get_schema_names())
+
+        # Want to have default schema always come first regardless of alpha order
+        all_schemas.remove(default_schema)
+        all_schemas.insert(0, default_schema)
+
+        data = {'Schema': all_schemas, 'Default': [sn == default_schema for sn in all_schemas]}
+
+        if invoked_as.endswith('+'):
+            # Want extra info -- namely, the table + view counts.
+            data['Table Count'] = [len(insp.get_table_names(sn)) for sn in all_schemas]
+
+            view_counts = [len(insp.get_view_names(sn)) for sn in all_schemas]
+            if any(view_counts):
+                data['View Count'] = view_counts
+
+        return DataFrame(data=data)
+
+
+# Populate simple registry of invocation command string -> concrete subclass.
+_registry = {}
+for cls in [SchemasCommand]:
+    for invoker in cls.invokers:
+        assert invoker not in _registry, f'Cannot register {invoker} for {cls}, already registered!'
+        _registry[invoker] = cls
+
+
+def run_meta_command(
+    shell: InteractiveShell, conn: Connection, command: str
+) -> Optional[DataFrame]:
+    """Dispatch to a MetaCommand implementation, return its result"""
+    command_words = command.strip().split()  # ['\foo', 'bar.blat']
+    invoker, args = command_words[0], command_words[1:]  # '\foo', ['bar.blat']
+
+    implementation_class = _registry.get(invoker)
+    if not implementation_class:
+        raise MetaCommandException(f'Unknown command {invoker}')
+
+    if args and not implementation_class.accepts_args:
+        raise MetaCommandInvocationException(
+            f'{invoker} does not expect arguments', invoked_with=invoker
+        )
+
+    instance = implementation_class(shell, conn)
+    return instance.run(invoker, args)

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -1,11 +1,9 @@
 from typing import Optional
 
+from IPython.core.interactiveshell import InteractiveShell
+from pandas import DataFrame
 from sqlalchemy import inspect
 from sqlalchemy.engine.reflection import Inspector
-
-from pandas import DataFrame
-
-from IPython.core.interactiveshell import InteractiveShell
 
 from noteable_magics.sql.connection import Connection
 
@@ -19,7 +17,7 @@ class MetaCommandException(Exception):
 
 
 class MetaCommandInvocationException(MetaCommandException):
-    """Invoked a specific meta command incorrectly.
+    r"""Invoked a specific meta command incorrectly.
 
     Will trigger sql-magic print() to suggest '\help \<subcommand>'
     """

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional
+from typing import Iterable, List, Optional
 
 from IPython.core.interactiveshell import InteractiveShell
 from pandas import DataFrame
@@ -40,7 +40,7 @@ class MetaCommand:
     # List of strings that will invoke this subclass.
     # Primary human-readable and memorable invocation string should come first, then any shorthand
     # aliases. See how global _registry is populated towards bottom of
-    invokers: list[str]
+    invokers: List[str]
 
     # Does this command accept additional arguments?
     accepts_args: bool
@@ -49,7 +49,7 @@ class MetaCommand:
         self.shell = shell
         self.conn = conn
 
-    def run(self, invoked_as: str, args: list[str]):
+    def run(self, invoked_as: str, args: List[str]):
         raise NotImplementedError
 
     def get_inspector(self) -> Inspector:

--- a/noteable_magics/sql/run.py
+++ b/noteable_magics/sql/run.py
@@ -5,11 +5,11 @@ import os.path
 import re
 from functools import reduce
 
-from jinjasql import JinjaSql
 import prettytable
 import six
 import sqlalchemy
 import sqlparse
+from jinjasql import JinjaSql
 
 from noteable_magics.sql.column_guesser import ColumnGuesserMixin
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -81,10 +81,10 @@ class TestDataLoaderMagic:
             ).scalar_one()
 
     def test_can_specify_alternate_connection_via_handle(
-        self, csv_file, data_loader, foo_database_connection
+        self, csv_file, data_loader, sqlite_database_connection
     ):
         """Test specifying non-default connection via --connection @sql_cell_handle"""
-        alternate_datasource_handle, human_name = foo_database_connection
+        alternate_datasource_handle, human_name = sqlite_database_connection
         assert alternate_datasource_handle != '@noteable'
         df = data_loader.execute(f"{csv_file} the_table --connection {alternate_datasource_handle}")
 
@@ -102,10 +102,10 @@ class TestDataLoaderMagic:
             )
 
     def test_can_specify_alternate_connection_via_human_name(
-        self, csv_file, data_loader, foo_database_connection
+        self, csv_file, data_loader, sqlite_database_connection
     ):
         """Test specifying non-default connection via --connection 'Human given datasource name'"""
-        _, human_name = foo_database_connection
+        _, human_name = sqlite_database_connection
 
         # human_name from fixture gots spaces in it, so must wrap in quotes.
         df = data_loader.execute(f"{csv_file} the_table --connection '{human_name}'")

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -1,0 +1,47 @@
+import pytest
+
+
+@pytest.mark.usefixtures("populated_sqlite_database")
+class TestListSchemas:
+    @pytest.mark.parametrize(
+        'invocation,expect_extras',
+        [
+            (r'\schemas', False),
+            (r'\schemas+', True),
+            (r'\dn', False),
+            (r'\dn+', True),
+        ],
+    )
+    def test_list_schemas(self, invocation: str, expect_extras: bool, sql_magic):
+
+        results = sql_magic.execute(f'@sqlite {invocation}')
+
+        # Sqlite just has one schema, 'main', and is the default.
+        assert len(results) == 1
+        assert results['Schema'][0] == 'main'
+
+        # wacky, if test with 'is', fails with 'assert True is True'
+        assert results['Default'][0] == True  # noqa: E712
+
+        if expect_extras:
+            assert results['Table Count'][0] == 2  # int_table, str_table.
+            # No views in this sqlite db
+            assert len(results.columns) == 3
+        else:
+            assert len(results.columns) == 2
+
+    def test_hates_arguments(self, sql_magic, capsys):
+        sql_magic.execute(r'@sqlite \schemas foo')
+        out, err = capsys.readouterr()
+        assert (
+            out
+            == '\\schemas does not expect arguments\n(Use "\\help \\schemas"" for more assistance)\n'
+        )
+
+
+@pytest.mark.usefixtures("populated_sqlite_database")
+class TestMisc:
+    def test_unknown_command(self, sql_magic, capsys):
+        sql_magic.execute(r'@sqlite \unknown_subcommand')
+        out, err = capsys.readouterr()
+        assert out == 'Unknown command \\unknown_subcommand\n(Use "\\help" for more assistance)\n'


### PR DESCRIPTION
…list out all schemas in this database.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

-  Meta-command subsystem for SQL cells. Will be used for realtime schema introspection within cells, etc. Commands can have aliases or alternate invocations which may or may not kick in additional functionality.
- Meta-commands will return a primary dataframe as their result. It is expected that the command to display structure of a single table or view will end up also directly emitting other dataframes as well, but a single one will also be directly returned.
- Implement first concrete command, `\schemas`, which will list all of the available schemas within the database the cell is run against. If run as `\schemas+`, will also count the tables and views (if any) within each schema. Also aliased as psql shorthand `\dn` (and in-house extension `\dn+`).
- Also implement `\help`:
  - if no argument, then will show all of the help
  - if a single argument, will provide just the help for that single command

While here:
- Refactor the sqlite-prepping fixture suite to live at toplevel conftest.py, improve names of these fixtures.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Users would have to know how to directly query `information_schema` or the equivalent in the database to reflect on the database.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Now we leverage SQLAlchemy and the database dialect's introspection capabilities to introspect into the database, using uniform commands inspired by PostgreSQL's `psql`'s backslash commands to get at this info irrespective of the actual database type.
