### PR TITLE
Implement meta commands \tables, \views, \list to return table/view/whatever names in schema(s).

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -214,10 +214,17 @@ def relation_names(
         if relations:
             schema_to_relations[s] = relations
 
+    if include_tables and include_views:
+        colname = 'Relations'
+    elif include_tables:
+        colname = 'Tables'
+    else:
+        colname = 'Views'
+
     return DataFrame(
         data={
             'Schema': list(schema_to_relations.keys()),
-            'Relations': [schema_to_relations[k] for k in schema_to_relations],
+            colname: [schema_to_relations[k] for k in schema_to_relations],
         }
     )
 

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -194,13 +194,13 @@ def relation_names(
 
     # Collect tables and / or views in each requested schema.
     schema_to_relations: Dict[str, str] = {}
-    for s in schemas:
+    for schema in schemas:
         # Some dialects return views as tables (and then also as views), so distict-ify via a set.
         relations = set()
         if include_tables:
-            relations.update(inspector.get_table_names(s))
+            relations.update(inspector.get_table_names(schema))
 
-        view_names = inspector.get_view_names(s)
+        view_names = inspector.get_view_names(schema)
         if include_views:
             relations.update(view_names)
         else:
@@ -209,10 +209,12 @@ def relation_names(
             relations.difference_update(view_names)
 
         # Convert passing-through-relation_name_filter names into a nice comma list
-        relations = ', '.join(sorted(r for r in relations if relation_name_filter.match(r)))
+        relations_comma_str = ', '.join(
+            sorted(r for r in relations if relation_name_filter.match(r))
+        )
 
-        if relations:
-            schema_to_relations[s] = relations
+        if relations_comma_str:
+            schema_to_relations[schema] = relations_comma_str
 
     if include_tables and include_views:
         colname = 'Relations'
@@ -273,14 +275,14 @@ def convert_relation_glob_to_regex(glob: str, imply_prefix=False) -> re.Pattern:
     """
     buf = []
     found_glob_char = False
-    for c in glob:
-        if ALLOWED_CHARS_RE.match(c):
-            buf.append(c)
-        elif c == '*':
+    for char in glob:
+        if ALLOWED_CHARS_RE.match(char):
+            buf.append(char)
+        elif char == '*':
             # Glob spelling '*' -> regex spelling '.*'
             buf.append('.*')
             found_glob_char = True
-        elif c == '?':
+        elif char == '?':
             # Glob spelling '?' -> regex spelling '.'
             buf.append('.')
             found_glob_char = True

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -1,7 +1,15 @@
+import re
+from typing import Optional, Tuple
+
 import pytest
+from sqlalchemy.engine.reflection import Inspector
 
 from noteable_magics.sql.connection import Connection
-from noteable_magics.sql.meta_commands import _all_command_classes
+from noteable_magics.sql.meta_commands import (
+    _all_command_classes,
+    convert_relation_glob_to_regex,
+    parse_schema_and_relation_glob,
+)
 
 
 @pytest.mark.usefixtures("populated_sqlite_database", "populated_cockroach_database")
@@ -16,10 +24,10 @@ class TestListSchemas:
     @pytest.mark.parametrize(
         'invocation,expect_extras',
         [
-            (r'schemas', False),
-            (r'schemas+', True),
-            (r'dn', False),
-            (r'dn+', True),
+            ('schemas', False),
+            ('schemas+', True),
+            ('dn', False),
+            ('dn+', True),
         ],
     )
     def test_list_schemas(
@@ -76,6 +84,127 @@ class TestListSchemas:
         )
 
 
+@pytest.mark.usefixtures("populated_sqlite_database", "populated_cockroach_database")
+class TestRelationsCommand:
+    @pytest.mark.parametrize(
+        'connection_handle',
+        [
+            '@sqlite',
+            '@cockroach',
+        ],
+    )
+    @pytest.mark.parametrize(
+        'invocation',
+        ['list', 'dr'],
+    )
+    @pytest.mark.parametrize(
+        'argument,exp_table_string',
+        [
+            ('', 'int_table, references_int_table, str_int_view, str_table'),
+            ('int*', 'int_table'),
+            ('int_tab??', 'int_table'),
+            ('*.int*', 'int_table'),
+            ('*int*', 'int_table, references_int_table, str_int_view'),
+        ],
+    )
+    def test_list_relations(
+        self,
+        connection_handle: str,
+        argument: str,
+        exp_table_string: str,
+        invocation: str,
+        sql_magic,
+    ):
+
+        invocation = f'\\{invocation}'
+        results = sql_magic.execute(f'{connection_handle} {invocation} {argument}')
+        assert len(results) == 1
+        assert results['Relations'][0] == exp_table_string
+
+    def test_list_relations_multiple_schemas(
+        self,
+        sql_magic,
+    ):
+        # Show all relations in all schemas.
+        results = sql_magic.execute(r'@cockroach \list *.*')
+        assert len(results) == 3
+        assert results['Schema'].tolist() == ['crdb_internal', 'information_schema', 'public']
+        assert results['Relations'][2] == 'int_table, references_int_table, str_int_view, str_table'
+
+        # Show all relations in single glob'd schema (matches 'public' only)
+        results = sql_magic.execute(r'@cockroach \list p*.*')
+        assert len(results) == 1
+        assert results['Schema'][0] == 'public'
+        assert results['Relations'][0] == 'int_table, references_int_table, str_int_view, str_table'
+
+        # Show all tables in default schema, which in crdb, happens to be named 'public'
+        # (either single asterisk arg, or no arg at all)
+        for invocation_and_maybe_arg in [r'\list *', r'\list']:
+            results = sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
+            assert len(results) == 1
+            assert results['Schema'][0] == 'public'
+            assert (
+                results['Relations'][0]
+                == 'int_table, references_int_table, str_int_view, str_table'
+            )
+
+
+@pytest.mark.usefixtures("populated_cockroach_database")
+class TestTablesCommand:
+    def test_list_tables(
+        self,
+        sql_magic,
+    ):
+        # Show only tables (no views) in all schemas.
+        results = sql_magic.execute(r'@cockroach \tables *.*')
+        assert len(results) == 3
+        assert results['Schema'].tolist() == ['crdb_internal', 'information_schema', 'public']
+        # No str_int_view!
+        assert results['Relations'][2] == 'int_table, references_int_table, str_table'
+
+        # Show all relations in single glob'd schema (matches 'public' only)
+        results = sql_magic.execute(r'@cockroach \tables p*.*')
+        assert len(results) == 1
+        assert results['Schema'][0] == 'public'
+        assert results['Relations'][0] == 'int_table, references_int_table, str_table'
+
+        # Show all tables in default schema, which in crdb, happens to be named 'public'
+        # (either single asterisk arg, or no arg at all)
+        for invocation_and_maybe_arg in [r'\tables *', r'\tables', r'\dt']:
+            results = sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
+            assert len(results) == 1
+            assert results['Schema'][0] == 'public'
+            assert results['Relations'][0] == 'int_table, references_int_table, str_table'
+
+
+@pytest.mark.usefixtures("populated_cockroach_database")
+class TestViewsCommand:
+    def test_list_tables(
+        self,
+        sql_magic,
+    ):
+        # Show only tables (no views) in all schemas.
+        results = sql_magic.execute(r'@cockroach \views *.*')
+        assert len(results) == 2
+        # Not exactly sure why it thinks 'information_schema' isn't chock full of views, but oh well.
+        assert results['Schema'].tolist() == ['crdb_internal', 'public']
+        assert results['Relations'][1] == 'str_int_view'
+
+        # Show all views in single glob'd schema (matches 'public' only)
+        results = sql_magic.execute(r'@cockroach \views p*.*')
+        assert len(results) == 1
+        assert results['Schema'][0] == 'public'
+        assert results['Relations'][0] == 'str_int_view'
+
+        # Show all views in default schema, which in crdb, happens to be named 'public'
+        # (either single asterisk arg, or no arg at all)
+        for invocation_and_maybe_arg in [r'\views *', r'\views', r'\dv']:
+            results = sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
+            assert len(results) == 1
+            assert results['Schema'][0] == 'public'
+            assert results['Relations'][0] == 'str_int_view'
+
+
 @pytest.mark.usefixtures("populated_sqlite_database")
 class TestHelp:
     def test_general_help(self, sql_magic):
@@ -110,3 +239,64 @@ class TestMisc:
         sql_magic.execute(r'@sqlite \unknown_subcommand')
         out, err = capsys.readouterr()
         assert out == 'Unknown command \\unknown_subcommand\n(Use "\\help" for more assistance)\n'
+
+
+class TestParseSchemaAndRelationGlob:
+    @pytest.mark.parametrize(
+        'inp,expected_result',
+        [
+            ('*.*', ('*', '*')),  # all schemas, all tables.
+            # no schema designator implies default schema. All tables starting with 'foo'
+            (
+                'foo*',
+                ('default', 'foo*'),
+            ),
+            (
+                'main.foo*',
+                ('main', 'foo*'),
+            ),  # Specific schema (main), all tables starting with foo.
+            ('*schema*.*', ('*schema*', '*')),  # Schemas matching glob *schema*, any tables within.
+        ],
+    )
+    def test_when_default_schema_is_available(
+        self, inp: str, expected_result: Tuple[Optional[str], Optional[str]], mocker
+    ):
+        mock_inspector = mocker.Mock(Inspector)
+        mock_inspector.default_schema_name = 'default'
+        assert parse_schema_and_relation_glob(mock_inspector, inp) == expected_result
+
+    def test_when_default_schema_is_not_available(self, mocker):
+        """Test when the dialect's inspector doesn't distinguish any schema as the default, as BigQuery and Trino do"""
+        mock_inspector = mocker.Mock(Inspector)
+        mock_inspector.default_schema_name = None
+        mock_inspector.get_schema_names.side_effect = lambda: ['first', 'random_schema']
+
+        assert parse_schema_and_relation_glob(mock_inspector, 'foo') == ('first', 'foo')
+        assert parse_schema_and_relation_glob(mock_inspector, '*') == ('first', '*')
+        assert parse_schema_and_relation_glob(mock_inspector, '.') == ('first', '*')
+        assert parse_schema_and_relation_glob(mock_inspector, 'schema.foo*') == ('schema', 'foo*')
+
+
+@pytest.mark.parametrize(
+    'inp,imply_prefix,expected_result',
+    [
+        # No glob chars at all imply prefix search if asked with imply_prefix
+        ('foo', True, re.compile('foo.*')),
+        ('foo', False, re.compile('foo')),
+        # Explicit prefix search.
+        ('foo*', False, re.compile('foo.*')),
+        # glob wildcard -> regex wildcard.
+        ('*', False, re.compile('.*')),
+        # Skip trash
+        ('f$%^&', True, re.compile('f.*')),
+        # Spaces preserved, FWIW.
+        ('foo_bar *', False, re.compile('foo_bar .*')),
+        # Question marks work too.
+        ('f??', True, re.compile('f..')),
+    ],
+)
+def test_convert_relation_glob_to_regex(
+    inp: str, imply_prefix, expected_result: Tuple[Optional[str], Optional[str]], mocker
+):
+
+    assert convert_relation_glob_to_regex(inp, imply_prefix=imply_prefix) == expected_result

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -160,13 +160,13 @@ class TestTablesCommand:
         assert len(results) == 3
         assert results['Schema'].tolist() == ['crdb_internal', 'information_schema', 'public']
         # No str_int_view!
-        assert results['Relations'][2] == 'int_table, references_int_table, str_table'
+        assert results['Tables'][2] == 'int_table, references_int_table, str_table'
 
         # Show all relations in single glob'd schema (matches 'public' only)
         results = sql_magic.execute(r'@cockroach \tables p*.*')
         assert len(results) == 1
         assert results['Schema'][0] == 'public'
-        assert results['Relations'][0] == 'int_table, references_int_table, str_table'
+        assert results['Tables'][0] == 'int_table, references_int_table, str_table'
 
         # Show all tables in default schema, which in crdb, happens to be named 'public'
         # (either single asterisk arg, or no arg at all)
@@ -174,7 +174,7 @@ class TestTablesCommand:
             results = sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
             assert len(results) == 1
             assert results['Schema'][0] == 'public'
-            assert results['Relations'][0] == 'int_table, references_int_table, str_table'
+            assert results['Tables'][0] == 'int_table, references_int_table, str_table'
 
 
 @pytest.mark.usefixtures("populated_cockroach_database")
@@ -188,13 +188,13 @@ class TestViewsCommand:
         assert len(results) == 2
         # Not exactly sure why it thinks 'information_schema' isn't chock full of views, but oh well.
         assert results['Schema'].tolist() == ['crdb_internal', 'public']
-        assert results['Relations'][1] == 'str_int_view'
+        assert results['Views'][1] == 'str_int_view'
 
         # Show all views in single glob'd schema (matches 'public' only)
         results = sql_magic.execute(r'@cockroach \views p*.*')
         assert len(results) == 1
         assert results['Schema'][0] == 'public'
-        assert results['Relations'][0] == 'str_int_view'
+        assert results['Views'][0] == 'str_int_view'
 
         # Show all views in default schema, which in crdb, happens to be named 'public'
         # (either single asterisk arg, or no arg at all)
@@ -202,7 +202,7 @@ class TestViewsCommand:
             results = sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
             assert len(results) == 1
             assert results['Schema'][0] == 'public'
-            assert results['Relations'][0] == 'str_int_view'
+            assert results['Views'][0] == 'str_int_view'
 
 
 @pytest.mark.usefixtures("populated_sqlite_database")


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Implement `\list` , `\tables` , `\views` (and aliases `\dr`, `\dt`, `\dv`) within SQL cells. See ENG-4996 for full specification of behavior.
