### PR TITLE
Prepare for displaying multiple dataframes in a single meta result (f…

### DIFF
--- a/noteable_magics/data_loader.py
+++ b/noteable_magics/data_loader.py
@@ -37,7 +37,6 @@ def get_db_connection(sql_cell_handle_or_human_name: str) -> Optional['Connectio
         return Connection.set(
             duckdb_location,
             human_name="Local Database",
-            displaycon=False,
             name=LOCAL_DB_CONN_HANDLE,
         )
     else:

--- a/noteable_magics/datasources.py
+++ b/noteable_magics/datasources.py
@@ -118,7 +118,6 @@ def bootstrap_datasource(
         connection_url,
         name=f'@{datasource_id}',
         human_name=human_name,
-        displaycon=False,
         **create_engine_kwargs,
     )
 

--- a/noteable_magics/sql/connection.py
+++ b/noteable_magics/sql/connection.py
@@ -1,4 +1,3 @@
-import os
 from typing import Dict, Optional, Union
 
 import sqlalchemy

--- a/noteable_magics/sql/connection.py
+++ b/noteable_magics/sql/connection.py
@@ -126,7 +126,6 @@ class Connection(object):
     def set(
         cls,
         descriptor: Union[str, 'Connection'],
-        displaycon: bool,
         name: Optional[str] = None,
         **create_engine_kwargs
     ):
@@ -143,17 +142,6 @@ class Connection(object):
                     name,
                     **create_engine_kwargs,
                 )
-        else:
-            if cls.connections:
-                if displaycon:
-                    print(cls.connection_list())
-            else:
-                if os.getenv("DATABASE_URL"):
-                    cls.current = Connection(os.getenv("DATABASE_URL"), **create_engine_kwargs)
-                else:
-                    raise ConnectionError(
-                        "Environment variable $DATABASE_URL not set, and no connect string given."
-                    )
         return cls.current
 
     @classmethod

--- a/noteable_magics/sql/magic.py
+++ b/noteable_magics/sql/magic.py
@@ -215,14 +215,15 @@ class SqlMagic(Magics, Configurable):
             return
 
         try:
+            # TODO: Strip any SQL comments out early / here.
             if parsed["sql"].startswith('\\'):
                 # Is a meta command, say, to introspect schema or table such as "\describe foo"
                 # May emit things directly as well as probably return a primary dataframe.
-                result = run_meta_command(self.shell, conn, parsed["sql"])
+                run_meta_command(self.shell, conn, parsed["sql"], parsed.get("result_var"))
+                return
 
-            else:
-                # Vanilla SQL statement.
-                result = noteable_magics.sql.run.run(conn, parsed["sql"], self, user_ns)
+            # Otherwise is a vanilla SQL statement.
+            result = noteable_magics.sql.run.run(conn, parsed["sql"], self, user_ns)
 
             if result is not None and not isinstance(result, str) and self.column_local_vars:
                 # Instead of returning values, set variables directly in the

--- a/noteable_magics/sql/magic.py
+++ b/noteable_magics/sql/magic.py
@@ -112,22 +112,23 @@ class SqlMagic(Magics, Configurable):
             return None
 
         if not parsed["sql"]:
+            # Nothing at all to do. Perhaps cell was all comments (stripped away inside of parse()) or otherwise blank?
             return
 
         try:
-            # TODO: Strip any SQL comments out early / here.
             if parsed["sql"].startswith('\\'):
                 # Is a meta command, say, to introspect schema or table such as "\describe foo"
-                # May emit things directly as well as probably return a primary dataframe.
+                # Will make calls to display() as well as handle doing any result_var assignments into
+                # self.shell.user_ns.
                 run_meta_command(self.shell, conn, parsed["sql"], parsed.get("result_var"))
                 return
 
-            # Otherwise is a vanilla SQL statement.
+            # Is a vanilla SQL statement. Run it.
             result = noteable_magics.sql.run.run(conn, parsed["sql"], self, user_ns)
 
             if parsed["result_var"]:
                 # Silently assign the result to this named variable, ENG-4711.
-                self.shell.user_ns.update({parsed["result_var"]: result})
+                self.shell.user_ns[parsed["result_var"]] = result
 
             # Always return query results into the default ipython _ variable
             return result

--- a/noteable_magics/sql/magic.py
+++ b/noteable_magics/sql/magic.py
@@ -32,8 +32,6 @@ class SqlMagic(Magics, Configurable):
 
     Provides the %%sql magic."""
 
-    autolimit = 0
-
     short_errors = Bool(
         True,
         config=True,

--- a/noteable_magics/sql/magic.py
+++ b/noteable_magics/sql/magic.py
@@ -1,8 +1,5 @@
-import json
-import re
-
 from IPython.core.magic import Magics, cell_magic, line_magic, magics_class, needs_local_scope
-from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
+from IPython.core.magic_arguments import argument, magic_arguments
 from sqlalchemy.exc import (
     DatabaseError,
     InterfaceError,
@@ -17,11 +14,11 @@ import noteable_magics.sql.run
 from noteable_magics.sql.meta_commands import MetaCommandException, run_meta_command
 
 try:
-    from traitlets import Bool, Int, Unicode
+    from traitlets import Bool
     from traitlets.config.configurable import Configurable
 except ImportError:
     from IPython.config.configurable import Configurable
-    from IPython.utils.traitlets import Bool, Int, Unicode
+    from IPython.utils.traitlets import Bool
 try:
     from pandas.core.frame import DataFrame, Series
 except ImportError:
@@ -35,46 +32,19 @@ class SqlMagic(Magics, Configurable):
 
     Provides the %%sql magic."""
 
-    displaycon = Bool(True, config=True, help="Show connection string after execute")
-    autolimit = Int(
-        0,
-        config=True,
-        allow_none=True,
-        help="Automatically limit the size of the returned result sets",
-    )
-    style = Unicode(
-        "DEFAULT",
-        config=True,
-        help="Set the table printing style to any of prettytable's defined styles (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)",
-    )
+    autolimit = 0
+
     short_errors = Bool(
         True,
         config=True,
         help="Don't display the full traceback on SQL Programming Error",
-    )
-    displaylimit = Int(
-        None,
-        config=True,
-        allow_none=True,
-        help="Automatically limit the number of rows displayed (full result set is still stored)",
     )
     autopandas = Bool(
         False,
         config=True,
         help="Return Pandas DataFrames instead of regular result sets",
     )
-    column_local_vars = Bool(
-        False, config=True, help="Return data into local variables from column names"
-    )
     feedback = Bool(True, config=True, help="Print number of rows affected by DML")
-    dsn_filename = Unicode(
-        "odbc.ini",
-        config=True,
-        help="Path to DSN file. "
-        "When the first argument is of the form [section], "
-        "a sqlalchemy connection string is formed from the "
-        "matching section in the DSN file.",
-    )
     autocommit = Bool(True, config=True, help="Set autocommit mode")
 
     def __init__(self, shell):
@@ -89,33 +59,6 @@ class SqlMagic(Magics, Configurable):
     @cell_magic("sql")
     @magic_arguments()
     @argument("line", default="", nargs="*", type=str, help="sql")
-    @argument("-l", "--connections", action="store_true", help="list active connections")
-    @argument("-x", "--close", type=str, help="close a session by name")
-    @argument("-c", "--creator", type=str, help="specify creator function for new connection")
-    @argument(
-        "-s",
-        "--section",
-        type=str,
-        help="section of dsn_file to be used for generating a connection string",
-    )
-    @argument(
-        "-p",
-        "--persist",
-        action="store_true",
-        help="create a table name in the database from the named DataFrame",
-    )
-    @argument(
-        "--append",
-        action="store_true",
-        help="create, or append to, a table name in the database from the named DataFrame",
-    )
-    @argument(
-        "-a",
-        "--connection_arguments",
-        type=str,
-        help="specify dictionary of connection arguments to pass to SQL driver",
-    )
-    @argument("-f", "--file", type=str, help="Run SQL from file at this path")
     def execute(self, line="", cell="", local_ns={}):  # noqa: C901
         """Runs SQL statement against a database, specified by SQLAlchemy connect string.
 
@@ -143,47 +86,15 @@ class SqlMagic(Magics, Configurable):
 
         """
 
-        line = noteable_magics.sql.parse.without_sql_comment(parser=self.execute.parser, line=line)
-        args = parse_argstring(self.execute, line)
-        if args.connections:
-            return noteable_magics.sql.connection.Connection.connections
-        elif args.close:
-            return noteable_magics.sql.connection.Connection._close(args.close)
-
         # save globals and locals so they can be referenced in bind vars
         user_ns = self.shell.user_ns.copy()
         user_ns.update(local_ns)
 
-        command_text = " ".join(args.line) + "\n" + cell
-
-        if args.file:
-            with open(args.file, "r") as infile:
-                command_text = infile.read() + "\n" + command_text
+        command_text = line + "\n" + cell
 
         parsed = noteable_magics.sql.parse.parse(command_text, self)
 
         connect_str = parsed["connection"]
-        if args.section:
-            connect_str = noteable_magics.sql.parse.connection_from_dsn_section(args.section, self)
-
-        if args.connection_arguments:
-            try:
-                # check for string deliniators, we need to strip them for json parse
-                raw_args = args.connection_arguments
-                if len(raw_args) > 1:
-                    targets = ['"', "'"]
-                    head = raw_args[0]
-                    tail = raw_args[-1]
-                    if head in targets and head == tail:
-                        raw_args = raw_args[1:-1]
-                args.connection_arguments = json.loads(raw_args)
-            except Exception as e:
-                print(e)
-                raise e
-        else:
-            args.connection_arguments = {}
-        if args.creator:
-            args.creator = user_ns[args.creator]
 
         # Get ahold of the connection to use. Original sql-magic lifecycle was to create connections
         # on the fly within cells via magic invocations. Said connection would then become the
@@ -196,20 +107,11 @@ class SqlMagic(Magics, Configurable):
         try:
             conn = noteable_magics.sql.connection.Connection.set(
                 connect_str,
-                displaycon=self.displaycon,
-                connect_args=args.connection_arguments,
-                creator=args.creator,
             )
         except noteable_magics.sql.connection.UnknownConnectionError as e:
             # Cell referenced a datasource we don't know about. Exception will have a short + sweet message.
             print(e)
             return None
-
-        if args.persist:
-            return self._persist_dataframe(parsed["sql"], conn, user_ns, append=False)
-
-        if args.append:
-            return self._persist_dataframe(parsed["sql"], conn, user_ns, append=True)
 
         if not parsed["sql"]:
             return
@@ -225,29 +127,12 @@ class SqlMagic(Magics, Configurable):
             # Otherwise is a vanilla SQL statement.
             result = noteable_magics.sql.run.run(conn, parsed["sql"], self, user_ns)
 
-            if result is not None and not isinstance(result, str) and self.column_local_vars:
-                # Instead of returning values, set variables directly in the
-                # users namespace. Variable names given by column names
+            if parsed["result_var"]:
+                # Silently assign the result to this named variable, ENG-4711.
+                self.shell.user_ns.update({parsed["result_var"]: result})
 
-                if self.autopandas:
-                    keys = result.keys()
-                else:
-                    keys = result.keys
-                    result = result.dict()
-
-                if self.feedback:
-                    print("Returning data to local variables [{}]".format(", ".join(keys)))
-
-                self.shell.user_ns.update(result)
-
-                return None
-            else:
-                if parsed["result_var"]:
-                    # Silently assign the result to this named variable, ENG-4711.
-                    self.shell.user_ns.update({parsed["result_var"]: result})
-
-                # Always return query results into the default ipython _ variable
-                return result
+            # Always return query results into the default ipython _ variable
+            return result
 
         except (
             ProgrammingError,
@@ -300,33 +185,6 @@ class SqlMagic(Magics, Configurable):
                     " Closed the connection just to be safe. Re-run the cell to try again!\n\n"
                 )
                 raise
-
-    legal_sql_identifier = re.compile(r"^[A-Za-z0-9#_$]+")
-
-    def _persist_dataframe(self, raw, conn, user_ns, append=False):
-        """Implements PERSIST, which writes a DataFrame to the RDBMS"""
-        if not DataFrame:
-            raise ImportError("Must `pip install pandas` to use DataFrames")
-
-        frame_name = raw.strip(";")
-
-        # Get the DataFrame from the user namespace
-        if not frame_name:
-            raise SyntaxError("Syntax: %sql --persist <name_of_data_frame>")
-        try:
-            frame = eval(frame_name, user_ns)
-        except SyntaxError:
-            raise SyntaxError("Syntax: %sql --persist <name_of_data_frame>")
-        if not isinstance(frame, DataFrame) and not isinstance(frame, Series):
-            raise TypeError("%s is not a Pandas DataFrame or Series" % frame_name)
-
-        # Make a suitable name for the resulting database table
-        table_name = frame_name.lower()
-        table_name = self.legal_sql_identifier.search(table_name).group(0)
-
-        if_exists = "append" if append else "fail"
-        frame.to_sql(table_name, conn.session.engine, if_exists=if_exists)
-        return "Persisted %s" % table_name
 
 
 def load_ipython_extension(ip):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,7 +169,7 @@ def sqlite_database_connection() -> Tuple[str, str]:
 
     handle = '@sqlite'
     human_name = "My Sqlite Connection"
-    Connection.set("sqlite:///:memory:", displaycon=False, name=handle, human_name=human_name)
+    Connection.set("sqlite:///:memory:", name=handle, human_name=human_name)
 
     return handle, human_name
 
@@ -193,7 +193,7 @@ def cockroach_database_connection(managed_cockroach: CockroachDetails) -> Tuple[
 
     handle = '@cockroach'
     human_name = "My Cockroach Connection"
-    Connection.set(managed_cockroach.sync_dsn, displaycon=False, name=handle, human_name=human_name)
+    Connection.set(managed_cockroach.sync_dsn, name=handle, human_name=human_name)
     return handle, human_name
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,18 @@ def sql_magic(ipython_shell) -> SqlMagic:
     return magic
 
 
+@pytest.fixture
+def ipython_namespace(ipython_shell):
+    return ipython_shell.user_ns
+
+
+@pytest.fixture
+def mock_display(mocker):
+    mock = mocker.Mock()
+    mocker.patch("noteable_magics.sql.meta_commands.display", mock)
+    return mock
+
+
 def populate_database(connection: Connection, include_comments=False):
 
     # Must actually do the table building transactionally, especially adding comments, else

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -37,12 +37,20 @@ class TestListSchemas:
         expected_results: dict,
         expect_extras: bool,
         sql_magic,
+        ipython_namespace,
+        mock_display,
     ):
         r"""Test \schemas variants against both sqlite and CRDB for basic sanity purposes"""
         # prepend the slash. Having the slashes in the paramterized spelling makes pytest's printout
         # of this variant icky and hard to invoke directly.
         invocation = f'\\{invocation}'
-        results = sql_magic.execute(f'{connection_handle} {invocation}')
+        sql_magic.execute(f'{connection_handle} {invocation}')
+
+        # The magic meta command does not return the dataframe, but instead
+        # directly calls display() and assigns into '_' (or to an arbitrary name
+        # if invoked with '<<')
+        results = ipython_namespace['_']
+        mock_display.assert_called_with(results)
 
         assert len(results) == expected_results['num_schemas']
         assert results['Schema'][0] == expected_results['primary_schema_name']
@@ -57,7 +65,12 @@ class TestListSchemas:
         else:
             assert results.columns.tolist() == ['Schema', 'Default']
 
-    def test_list_schemas_when_no_views(self, sql_magic):
+    def test_list_schemas_when_no_views(
+        self,
+        sql_magic,
+        ipython_namespace,
+        mock_display,
+    ):
         r"""Prove that when no views exist, \schemas+ does not talk at all about a 'View Count' column"""
 
         # Drop the view.
@@ -65,7 +78,9 @@ class TestListSchemas:
         db = connection.session  # sic, a sqlalchemy.engine.base.Connection, not a Session. Sigh.
         db.execute('drop view str_int_view')
 
-        results = sql_magic.execute(r'@sqlite \schemas+')
+        sql_magic.execute(r'@sqlite \schemas+')
+        results = ipython_namespace['_']
+        mock_display.assert_called_with(results)
 
         assert len(results) == 1
 
@@ -114,25 +129,38 @@ class TestRelationsCommand:
         exp_table_string: str,
         invocation: str,
         sql_magic,
+        ipython_namespace,
+        mock_display,
     ):
 
         invocation = f'\\{invocation}'
-        results = sql_magic.execute(f'{connection_handle} {invocation} {argument}')
+        sql_magic.execute(f'{connection_handle} {invocation} {argument}')
+
+        results = ipython_namespace['_']
+        mock_display.assert_called_with(results)
+
         assert len(results) == 1
         assert results['Relations'][0] == exp_table_string
 
     def test_list_relations_multiple_schemas(
         self,
         sql_magic,
+        ipython_namespace,
+        mock_display,
     ):
         # Show all relations in all schemas.
-        results = sql_magic.execute(r'@cockroach \list *.*')
+        sql_magic.execute(r'@cockroach \list *.*')
+
+        results = ipython_namespace['_']
+        mock_display.assert_called_with(results)
+
         assert len(results) == 3
         assert results['Schema'].tolist() == ['crdb_internal', 'information_schema', 'public']
         assert results['Relations'][2] == 'int_table, references_int_table, str_int_view, str_table'
 
         # Show all relations in single glob'd schema (matches 'public' only)
-        results = sql_magic.execute(r'@cockroach \list p*.*')
+        sql_magic.execute(r'@cockroach \list p*.*')
+        results = ipython_namespace['_']
         assert len(results) == 1
         assert results['Schema'][0] == 'public'
         assert results['Relations'][0] == 'int_table, references_int_table, str_int_view, str_table'
@@ -140,7 +168,8 @@ class TestRelationsCommand:
         # Show all tables in default schema, which in crdb, happens to be named 'public'
         # (either single asterisk arg, or no arg at all)
         for invocation_and_maybe_arg in [r'\list *', r'\list']:
-            results = sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
+            sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
+            results = ipython_namespace['_']
             assert len(results) == 1
             assert results['Schema'][0] == 'public'
             assert (
@@ -154,16 +183,24 @@ class TestTablesCommand:
     def test_list_tables(
         self,
         sql_magic,
+        ipython_namespace,
+        mock_display,
     ):
-        # Show only tables (no views) in all schemas.
-        results = sql_magic.execute(r'@cockroach \tables *.*')
+        # Show only tables (no views) in all schemas. Also test out assignment to non='_' var.
+        results = sql_magic.execute(r'@cockroach tables << \tables *.*')
+
+        results = ipython_namespace['tables']
+        mock_display.assert_called_with(results)
+
         assert len(results) == 3
         assert results['Schema'].tolist() == ['crdb_internal', 'information_schema', 'public']
         # No str_int_view!
         assert results['Tables'][2] == 'int_table, references_int_table, str_table'
 
         # Show all relations in single glob'd schema (matches 'public' only)
-        results = sql_magic.execute(r'@cockroach \tables p*.*')
+        sql_magic.execute(r'@cockroach \tables p*.*')
+        results = ipython_namespace['_']
+
         assert len(results) == 1
         assert results['Schema'][0] == 'public'
         assert results['Tables'][0] == 'int_table, references_int_table, str_table'
@@ -171,7 +208,9 @@ class TestTablesCommand:
         # Show all tables in default schema, which in crdb, happens to be named 'public'
         # (either single asterisk arg, or no arg at all)
         for invocation_and_maybe_arg in [r'\tables *', r'\tables', r'\dt']:
-            results = sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
+            sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
+            results = ipython_namespace['_']
+
             assert len(results) == 1
             assert results['Schema'][0] == 'public'
             assert results['Tables'][0] == 'int_table, references_int_table, str_table'
@@ -179,19 +218,19 @@ class TestTablesCommand:
 
 @pytest.mark.usefixtures("populated_cockroach_database")
 class TestViewsCommand:
-    def test_list_tables(
-        self,
-        sql_magic,
-    ):
+    def test_list_tables(self, sql_magic, ipython_namespace):
         # Show only tables (no views) in all schemas.
-        results = sql_magic.execute(r'@cockroach \views *.*')
+        sql_magic.execute(r'@cockroach \views *.*')
+        results = ipython_namespace['_']
+
         assert len(results) == 2
         # Not exactly sure why it thinks 'information_schema' isn't chock full of views, but oh well.
         assert results['Schema'].tolist() == ['crdb_internal', 'public']
         assert results['Views'][1] == 'str_int_view'
 
         # Show all views in single glob'd schema (matches 'public' only)
-        results = sql_magic.execute(r'@cockroach \views p*.*')
+        sql_magic.execute(r'@cockroach \views p*.*')
+        results = ipython_namespace['_']
         assert len(results) == 1
         assert results['Schema'][0] == 'public'
         assert results['Views'][0] == 'str_int_view'
@@ -199,7 +238,8 @@ class TestViewsCommand:
         # Show all views in default schema, which in crdb, happens to be named 'public'
         # (either single asterisk arg, or no arg at all)
         for invocation_and_maybe_arg in [r'\views *', r'\views', r'\dv']:
-            results = sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
+            sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
+            results = ipython_namespace['_']
             assert len(results) == 1
             assert results['Schema'][0] == 'public'
             assert results['Views'][0] == 'str_int_view'
@@ -210,8 +250,12 @@ class TestSingleRelationCommand:
     @pytest.mark.parametrize(
         'handle,defaults_include_int8', [('@cockroach', True), ('@sqlite', False)]
     )
-    def test_table_without_schema(self, sql_magic, handle: str, defaults_include_int8: bool):
-        results = sql_magic.execute(fr'{handle} \describe int_table')
+    def test_table_without_schema(
+        self, sql_magic, ipython_namespace, handle: str, defaults_include_int8: bool
+    ):
+        sql_magic.execute(fr'{handle} \describe int_table')
+        results = ipython_namespace['_']
+
         assert len(results) == 3
         assert results.columns.tolist() == ['Column', 'Type', 'Nullable', 'Default']
         assert results['Column'].tolist() == ['a', 'b', 'c']
@@ -227,16 +271,20 @@ class TestSingleRelationCommand:
         assert results['Default'].tolist() == expected_defaults
 
     @pytest.mark.parametrize('invocation', [r'\describe', r'\d'])
-    def test_varying_invocation(self, sql_magic, invocation: str):
-        results = sql_magic.execute(rf'@cockroach {invocation} public.int_table')
+    def test_varying_invocation(self, sql_magic, ipython_namespace, invocation: str):
+        sql_magic.execute(rf'@cockroach {invocation} public.int_table')
+        results = ipython_namespace['_']
+
         assert len(results) == 3
         assert results['Column'].tolist() == ['a', 'b', 'c']
         assert results['Type'].tolist() == ['integer'] * 3
         assert results['Nullable'].tolist() == [False] * 3
 
     @pytest.mark.parametrize('handle,text_type', [('@cockroach', 'varchar'), ('@sqlite', 'text')])
-    def test_against_view(self, sql_magic, handle: str, text_type: str):
-        results = sql_magic.execute(fr'{handle} \describe str_int_view')
+    def test_against_view(self, sql_magic, ipython_namespace, handle: str, text_type: str):
+        sql_magic.execute(fr'{handle} \describe str_int_view')
+        results = ipython_namespace['_']
+
         assert len(results) == 4
         assert results['Column'].tolist() == ['str_id', 'int_col', 'b', 'c']
         assert results['Type'].tolist() == [text_type, 'integer', 'integer', 'integer']
@@ -247,8 +295,10 @@ class TestSingleRelationCommand:
         # so we don't get them returned. We try, though!
         assert results.columns.tolist() == ['Column', 'Type', 'Nullable']
 
-    def test_no_args_gets_table_list(self, sql_magic):
-        results = sql_magic.execute(r'@sqlite \d')
+    def test_no_args_gets_table_list(self, sql_magic, ipython_namespace):
+        sql_magic.execute(r'@sqlite \d')
+        results = ipython_namespace['_']
+
         # Should have given us schema + table list instead of single-table details.
         assert len(results) == 1
         assert results.columns.tolist() == ['Schema', 'Relations']
@@ -276,15 +326,19 @@ class TestSingleRelationCommand:
 
 @pytest.mark.usefixtures("populated_sqlite_database")
 class TestHelp:
-    def test_general_help(self, sql_magic):
-        results = sql_magic.execute(r'@sqlite \help')
+    def test_general_help(self, sql_magic, ipython_namespace):
+        sql_magic.execute(r'@sqlite \help')
+        results = ipython_namespace['_']
+
         assert len(results) == len(_all_command_classes) - 1  # avoids talking about HelpCommand
         assert results.columns.tolist() == ['Description', 'Documentation', 'Invoke Using One Of']
 
     # Both these specific commands should regurgitate the same help row.
     @pytest.mark.parametrize('cmdname', [r'\schemas', r'\dn+'])
-    def test_single_topic_help(self, cmdname, sql_magic):
-        results = sql_magic.execute(rf'@sqlite \help {cmdname}')
+    def test_single_topic_help(self, cmdname, sql_magic, ipython_namespace):
+        sql_magic.execute(rf'@sqlite \help {cmdname}')
+        results = ipython_namespace['_']
+
         assert len(results) == 1
         assert results.columns.tolist() == ['Description', 'Documentation', 'Invoke Using One Of']
         assert results['Description'][0] == 'List schemas (namespaces) within database'


### PR DESCRIPTION
…or displaying indices, foreign keys of a single table, or a HTML blob of the view definition)

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Apologies in advance for a mixed topic PR:
  * Removes some amount of inherited dead-to-us code inherited from upstream sql-magics:
    * Simplify noteable_magics.sql.connection.Connection.set() call -- no more `displaycon` param / handling.
    * Remove many configuration settings handled by SqlMagic: No more `displaycon`, `style`, `displaylimit`, `column_local_vars`, `dsn_filename` --- all knobs for code we don't use or document.
    *  Remove many sql cell magic parameters --- all knobs for code we don't use or document:
        * `--connections` to list current connections
        * `--close`, close a connection by name
        * `--creator`, specify a connection 'creator' function.
        * `--section`, naming what section of 'dsn file' to get connection details from
        * `--persist`, to create a new SQL table from the query's dataframe
        * `--append`, to write additional rows to a preexisting table
        * `--connection-arguments`, to pass more details when creating a connection (we create connections completely differently)
        * `--file`, get SQL to run from a file, not the cell itself.
        
     * Net result is order of magnitude simpler code in `SqlMagic.execute()`
  * Adjust lifecyle of the SQL meta command objects:
    * Set up so that more than one dataframe can be `display()`ed within the execution of a meta command, clearing the way for the single-table inspector to display multiple dataframes (one for main structure of table, one for foreign keys, one for indexes, etc.).
    * The MetaCommand instance is now also responsible for performing the assignment into the sql cell dataframe name, out of whichever dataframe (if multiple) it decides is the 'main' one. Right now all only return a single one, but soon `SingleRelationCommand` will be `display()`ing more than one dataframe yet assigning the main one to the requested name. This made the test suite uglier, unfortunately, however, since a meta command's main dataframe is no longer returned directly by the SQL magic, but instead assigned into ipython user namespace as side-effect.
    * New driver method `do_run()` which downcalls into `run()`, performs the main dataframe assignment, and makes the explicit `display()` call.
    
* Adjust SQL cell contents parsing to do the right thing if the cell starts with a SQL comment line, then on the next line invokes a meta command, such as:

```
--This line will show all of the schemas in the database
\schemas
```
(new test `test_handles_sql_comment_at_front` covers this)

(It was the late discovery that the above didn't work which led to stripping out all of the inherited code that warranted the call to `args = parse_argstring(self.execute, line)` which was indirectly causing the above to not do the right thing that then made this PR the urban sprawl that it is)

## Coming next, facilitated by this work:
  * Have `\table` or `\view` fetch and display additional dataframes or outputs, such as indices, foreign keys, or in the case of views, the view definition (as a HTML \<pre> blob, not a dataframe).