### PR TITLE
Display an additional HTML blob showing the view's definition when ...

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -2,8 +2,7 @@ import re
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from IPython.core.interactiveshell import InteractiveShell
-from IPython.display import display, HTML
-
+from IPython.display import HTML, display
 from pandas import DataFrame
 from sqlalchemy import inspect
 from sqlalchemy.engine.reflection import Inspector

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -2,7 +2,7 @@ import re
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from IPython.core.interactiveshell import InteractiveShell
-from IPython.display import display
+from IPython.display import display, HTML
 
 from pandas import DataFrame
 from sqlalchemy import inspect
@@ -390,6 +390,19 @@ class SingleRelationCommand(MetaCommand):
         main_relation_structure = DataFrame(data=data)
         display(main_relation_structure)
 
+        if is_view:
+            view_definition = inspector.get_view_definition(relation_name, schema)
+
+            # Would not surprise me if some dialects do not implement / return anything, so be cautious.
+            if view_definition:
+                display_view_name = displayable_relation_name(schema, relation_name)  # noqa: F841
+                html_buf = []
+                html_buf.append(f'<h2>View {display_view_name!r} Definition:</h2>')
+                html_buf.append('<br />')
+                html_buf.append(f'<pre>{view_definition}</pre>')
+
+                display(HTML('\n'.join(html_buf)))
+
         return main_relation_structure, False
 
         """
@@ -477,6 +490,13 @@ class HelpCommand(MetaCommand):
             ),
             True,
         )
+
+
+def displayable_relation_name(schema: Optional[str], relation_name: str) -> str:
+    if schema:
+        return f'{schema}.{relation_name}'
+    else:
+        return relation_name
 
 
 # Populate simple registry of invocation command string -> concrete subclass.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,9 +115,7 @@ def ipython_namespace(ipython_shell):
 
 @pytest.fixture
 def mock_display(mocker):
-    mock = mocker.Mock()
-    mocker.patch("noteable_magics.sql.meta_commands.display", mock)
-    return mock
+    return mocker.patch("noteable_magics.sql.meta_commands.display")
 
 
 def populate_database(connection: Connection, include_comments=False):

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -1,10 +1,9 @@
 import re
 from typing import Optional, Tuple
 
-from IPython.display import HTML
-
 import pandas as pd
 import pytest
+from IPython.display import HTML
 from sqlalchemy.engine.reflection import Inspector
 
 from noteable_magics.sql.connection import Connection


### PR DESCRIPTION
`\describ`-ing a view.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Make a 2nd `display()` call with a HTML blob consisting of an `<h2>` with a title message, a `<br />`, and then a `<pre>` blob of the view's definition when the user `\describe`s a view.
- This HTML blob will only be displayed, will not be captured in the 'assign results to' variable.