### PR TITLE
Tweak SQL cell meta commands / outputs

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Iterable, List, Optional, Tuple
 
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.display import HTML, display
@@ -240,7 +240,7 @@ def relation_names(
             # to explicitly remove the definite view names. Thanks, guys.
             relations.difference_update(view_names)
 
-        # Filter, sort, append pair of (schema, relname) onto schema_and_relations
+        # Filter, sort, append schema, relname and possibly the kind onto respective lists.
         for relname in sorted(r for r in relations if relation_name_filter.match(r)):
             output_schemas.append(schema)
             output_relations.append(relname)
@@ -403,7 +403,7 @@ class SingleRelationCommand(MetaCommand):
                 display_view_name = displayable_relation_name(schema, relation_name)  # noqa: F841
                 html_buf = []
                 html_buf.append('<br />')
-                html_buf.append(f'<h2>View {display_view_name!r} Definition:</h2>')
+                html_buf.append(f'<h2>View "{display_view_name}" Definition</h2>')
                 html_buf.append('<br />')
                 html_buf.append(f'<pre>{view_definition}</pre>')
 

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -402,6 +402,7 @@ class SingleRelationCommand(MetaCommand):
             if view_definition:
                 display_view_name = displayable_relation_name(schema, relation_name)  # noqa: F841
                 html_buf = []
+                html_buf.append('<br />')
                 html_buf.append(f'<h2>View {display_view_name!r} Definition:</h2>')
                 html_buf.append('<br />')
                 html_buf.append(f'<pre>{view_definition}</pre>')

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import pandas as pd
 import pytest
@@ -115,20 +115,20 @@ class TestRelationsCommand:
         ['list', 'dr'],
     )
     @pytest.mark.parametrize(
-        'argument,exp_table_string',
+        'argument,exp_relations',
         [
-            ('', 'int_table, references_int_table, str_int_view, str_table'),
-            ('int*', 'int_table'),
-            ('int_tab??', 'int_table'),
-            ('*.int*', 'int_table'),
-            ('*int*', 'int_table, references_int_table, str_int_view'),
+            ('', ['int_table', 'references_int_table', 'str_int_view', 'str_table']),
+            ('int*', ['int_table']),
+            ('int_tab??', ['int_table']),
+            ('*.int*', ['int_table']),
+            ('*int*', ['int_table', 'references_int_table', 'str_int_view']),
         ],
     )
     def test_list_relations(
         self,
         connection_handle: str,
         argument: str,
-        exp_table_string: str,
+        exp_relations: List[str],
         invocation: str,
         sql_magic,
         ipython_namespace,
@@ -141,8 +141,7 @@ class TestRelationsCommand:
         results = ipython_namespace['_']
         mock_display.assert_called_with(results)
 
-        assert len(results) == 1
-        assert results['Relations'][0] == exp_table_string
+        assert results['Relations'].tolist() == exp_relations
 
     def test_list_relations_multiple_schemas(
         self,
@@ -156,28 +155,43 @@ class TestRelationsCommand:
         results = ipython_namespace['_']
         mock_display.assert_called_with(results)
 
-        assert len(results) == 3
-        assert results['Schema'].tolist() == ['crdb_internal', 'information_schema', 'public']
-        assert results['Relations'][2] == 'int_table, references_int_table, str_int_view, str_table'
+        assert len(results) > 100  # information_schema, crdb_internal have very many members.
+        assert set(results['Schema'].tolist()) == set(
+            ('crdb_internal', 'information_schema', 'public')
+        )
+
+        assert results[results.Schema == 'public']['Relations'].tolist() == [
+            'int_table',
+            'references_int_table',
+            'str_int_view',
+            'str_table',
+        ]
 
         # Show all relations in single glob'd schema (matches 'public' only)
         sql_magic.execute(r'@cockroach \list p*.*')
         results = ipython_namespace['_']
-        assert len(results) == 1
-        assert results['Schema'][0] == 'public'
-        assert results['Relations'][0] == 'int_table, references_int_table, str_int_view, str_table'
+        assert len(results) == 4
+        assert set(results['Schema'].tolist()) == set(('public',))
+        assert results['Relations'].tolist() == [
+            'int_table',
+            'references_int_table',
+            'str_int_view',
+            'str_table',
+        ]
 
         # Show all tables in default schema, which in crdb, happens to be named 'public'
         # (either single asterisk arg, or no arg at all)
         for invocation_and_maybe_arg in [r'\list *', r'\list']:
             sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
             results = ipython_namespace['_']
-            assert len(results) == 1
+            assert len(results) == 4
             assert results['Schema'][0] == 'public'
-            assert (
-                results['Relations'][0]
-                == 'int_table, references_int_table, str_int_view, str_table'
-            )
+            assert results['Relations'].tolist() == [
+                'int_table',
+                'references_int_table',
+                'str_int_view',
+                'str_table',
+            ]
 
 
 @pytest.mark.usefixtures("populated_cockroach_database")
@@ -194,18 +208,24 @@ class TestTablesCommand:
         results = ipython_namespace['tables']
         mock_display.assert_called_with(results)
 
-        assert len(results) == 3
-        assert results['Schema'].tolist() == ['crdb_internal', 'information_schema', 'public']
+        assert len(results) > 100  # crdb_internal, information schema have lots.
+        assert set(results['Schema'].tolist()) == set(
+            ['crdb_internal', 'information_schema', 'public']
+        )
         # No str_int_view!
-        assert results['Tables'][2] == 'int_table, references_int_table, str_table'
+        assert results[results.Schema == 'public']['Tables'].tolist() == [
+            'int_table',
+            'references_int_table',
+            'str_table',
+        ]
 
         # Show all relations in single glob'd schema (matches 'public' only)
         sql_magic.execute(r'@cockroach \tables p*.*')
         results = ipython_namespace['_']
 
-        assert len(results) == 1
-        assert results['Schema'][0] == 'public'
-        assert results['Tables'][0] == 'int_table, references_int_table, str_table'
+        assert len(results) == 3
+        assert set(results['Schema'].tolist()) == set(('public',))
+        assert results['Tables'].tolist() == ['int_table', 'references_int_table', 'str_table']
 
         # Show all tables in default schema, which in crdb, happens to be named 'public'
         # (either single asterisk arg, or no arg at all)
@@ -213,9 +233,9 @@ class TestTablesCommand:
             sql_magic.execute(f'@cockroach {invocation_and_maybe_arg}')
             results = ipython_namespace['_']
 
-            assert len(results) == 1
-            assert results['Schema'][0] == 'public'
-            assert results['Tables'][0] == 'int_table, references_int_table, str_table'
+        assert len(results) == 3
+        assert set(results['Schema'].tolist()) == set(('public',))
+        assert results['Tables'].tolist() == ['int_table', 'references_int_table', 'str_table']
 
 
 @pytest.mark.usefixtures("populated_cockroach_database")
@@ -225,10 +245,9 @@ class TestViewsCommand:
         sql_magic.execute(r'@cockroach \views *.*')
         results = ipython_namespace['_']
 
-        assert len(results) == 2
         # Not exactly sure why it thinks 'information_schema' isn't chock full of views, but oh well.
-        assert results['Schema'].tolist() == ['crdb_internal', 'public']
-        assert results['Views'][1] == 'str_int_view'
+        assert results['Schema'].unique().tolist() == ['crdb_internal', 'public']
+        assert results[results.Schema == 'public']['Views'].tolist() == ['str_int_view']
 
         # Show all views in single glob'd schema (matches 'public' only)
         sql_magic.execute(r'@cockroach \views p*.*')
@@ -337,8 +356,14 @@ class TestSingleRelationCommand:
         results = ipython_namespace['_']
 
         # Should have given us schema + table list instead of single-table details.
-        assert len(results) == 1
+        assert len(results) == 4
         assert results.columns.tolist() == ['Schema', 'Relations']
+        assert results['Relations'].tolist() == [
+            'int_table',
+            'references_int_table',
+            'str_int_view',
+            'str_table',
+        ]
 
     def test_hate_more_than_one_arg(self, sql_magic, capsys):
         sql_magic.execute(r'@sqlite \d foo bar')
@@ -368,7 +393,7 @@ class TestHelp:
         results = ipython_namespace['_']
 
         assert len(results) == len(_all_command_classes) - 1  # avoids talking about HelpCommand
-        assert results.columns.tolist() == ['Description', 'Documentation', 'Invoke Using One Of']
+        assert results.columns.tolist() == ['Command', 'Description', 'Documentation']
 
     # Both these specific commands should regurgitate the same help row.
     @pytest.mark.parametrize('cmdname', [r'\schemas', r'\dn+'])
@@ -377,9 +402,9 @@ class TestHelp:
         results = ipython_namespace['_']
 
         assert len(results) == 1
-        assert results.columns.tolist() == ['Description', 'Documentation', 'Invoke Using One Of']
+        assert results.columns.tolist() == ['Command', 'Description', 'Documentation']
         assert results['Description'][0] == 'List schemas (namespaces) within database'
-        assert results['Invoke Using One Of'][0] == r'\schemas, \schemas+, \dn, \dn+'
+        assert results['Command'][0] == r'\schemas, \schemas+, \dn, \dn+'
         assert results['Documentation'][0].startswith('List all the schemas')
 
     def test_help_hates_unknown_subcommands(self, sql_magic, capsys):
@@ -408,9 +433,9 @@ class TestMisc:
         out, err = capsys.readouterr()
 
         assert type(help_df) is pd.DataFrame
-        assert help_df.columns.tolist() == ['Description', 'Documentation', 'Invoke Using One Of']
+        assert help_df.columns.tolist() == ['Command', 'Description', 'Documentation']
         assert (
-            'List names of tables and views within database' in out
+            'List all the relations (tables and views)' in out
         )  # ... amoungst other things that \\help outputs!
 
 

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -258,7 +258,7 @@ class TestViewsCommand:
         results = ipython_namespace['_']
 
         # Not exactly sure why it thinks 'information_schema' isn't chock full of views, but oh well.
-        assert results.columns.tolist == ['Schema', 'View']
+        assert results.columns.tolist() == ['Schema', 'View']
         assert results['Schema'].unique().tolist() == ['crdb_internal', 'public']
         assert results[results.Schema == 'public']['View'].tolist() == ['str_int_view']
 
@@ -343,7 +343,7 @@ class TestSingleRelationCommand:
         html_obj = mock_display.call_args_list[1].args[0]
         assert isinstance(html_obj, HTML)
         html_contents: str = html_obj.data
-        assert html_contents.startswith("<h2>View 'str_int_view' Definition:</h2>")
+        assert html_contents.startswith("<br />\n<h2>View 'str_int_view' Definition:</h2>")
         # Some dialects include a 'CREATE VIEW' statement, others just start with 'select\n', and will vary by case.
         matcher = re.compile(
             '.*<pre>.*select.*s.str_id, s.int_col.*</pre>$',
@@ -361,7 +361,7 @@ class TestSingleRelationCommand:
         assert isinstance(html_obj, HTML)
         html_contents: str = html_obj.data
         assert html_contents.startswith(
-            "<h2>View 'public.str_int_view' Definition:</h2>"
+            "<br />\n<h2>View 'public.str_int_view' Definition:</h2>"
         ), html_contents
 
     def test_no_args_gets_table_list(self, sql_magic, ipython_namespace):

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -343,7 +343,7 @@ class TestSingleRelationCommand:
         html_obj = mock_display.call_args_list[1].args[0]
         assert isinstance(html_obj, HTML)
         html_contents: str = html_obj.data
-        assert html_contents.startswith("<br />\n<h2>View 'str_int_view' Definition:</h2>")
+        assert html_contents.startswith('<br />\n<h2>View "str_int_view" Definition</h2>')
         # Some dialects include a 'CREATE VIEW' statement, others just start with 'select\n', and will vary by case.
         matcher = re.compile(
             '.*<pre>.*select.*s.str_id, s.int_col.*</pre>$',
@@ -361,7 +361,7 @@ class TestSingleRelationCommand:
         assert isinstance(html_obj, HTML)
         html_contents: str = html_obj.data
         assert html_contents.startswith(
-            "<br />\n<h2>View 'public.str_int_view' Definition:</h2>"
+            '<br />\n<h2>View "public.str_int_view" Definition</h2>'
         ), html_contents
 
     def test_no_args_gets_table_list(self, sql_magic, ipython_namespace):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
Presentation tweaks for currently implemented functionality.

Given feedback on https://app.noteable-integration.us/f/87245cba-be66-4e76-baab-f200fdf143cb/Scratch.ipynb :

- Reorder columns and rows of \help to try to get the most important things first.
- One row per schema + relation from \list variants instead of one row per schema only, then with the relation names comma joined slammed into single dataframe cell.
- When running \list / \dr , inject additional column clarifying if relation is a table or a view.
- Add a \<br /> at the start of a view definition HTML block to space it out a bit from the bottom of the structure table. Is too tight right now.