### PR TITLE
Show information about indices defined on a table when doing \describe <table>

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -32,8 +32,13 @@ class MetaCommandInvocationException(MetaCommandException):
 
 
 class MetaCommand:
-    """Base class for family of metadata commands to do operations like schema-introspection, etc.
+    r"""Base class for family of metadata commands to do operations like schema-introspection, etc.
     within SQL cells.
+
+    The docstring of each concrete subclass will be 'published' as a part of the documentation
+    exposed by "\help" in a SQL cell, so keep 'em end-user friendly.
+
+    (See HelpCommand grabbing .__doc__ from each of the concrete subclasses)
     """
 
     # One-line description of what this one does.
@@ -392,8 +397,8 @@ class SingleRelationCommand(MetaCommand):
         if any(comments):
             data['Comment'] = comments
 
-        main_relation_structure = DataFrame(data=data)
-        display(main_relation_structure)
+        main_relation_df = DataFrame(data=data)
+        display(main_relation_df)
 
         if is_view:
             view_definition = inspector.get_view_definition(relation_name, schema)
@@ -409,32 +414,13 @@ class SingleRelationCommand(MetaCommand):
 
                 display(HTML('\n'.join(html_buf)))
         else:
-            # Is a table. Let's go get indices.
+            # Is a table. Let's go get indices and transform to a dataframe for
+            # presentation.
             index_df = index_dataframe(inspector, relation_name, schema)
             if len(index_df):
                 display(index_df)
 
-        return main_relation_structure, False
-
-        """
-        # Soon to become ...
-        df.attrs.update(
-            {
-                'noteable': {
-                    'dex': {
-                        'table_style': 'simple'
-                    }
-                    'view': {
-                        'title': 'Schema for table foo.bar',
-                        'subtitle': 'table-wide comment goes here',
-                        'show_index': False,
-                    }
-                }
-            }
-        )
-
-        display(df)
-        """
+        return main_relation_df, False
 
     @staticmethod
     def _split_schema_table(schema_table: str) -> Tuple[Optional[str], str]:
@@ -451,20 +437,21 @@ class SingleRelationCommand(MetaCommand):
 
 
 def index_dataframe(inspector: Inspector, table_name: str, schema: Optional[str]) -> DataFrame:
-    """Convert results from inspector.get_indexes for a table to a single dataframe"""
+    """Transform results from inspector.get_indexes() into a single dataframe for display() purposes"""
 
     index_dicts: List[Dict[str, Any]] = inspector.get_indexes(table_name, schema)
 
     index_names: List[str] = []
-    column_lists: List[List[str]] = []
+    column_lists: List[str] = []
     uniques: List[bool] = []
 
     for i_d in sorted(index_dicts, key=lambda d: d['name']):
         index_names.append(i_d['name'])
-        column_lists.append(i_d['column_names'])
+        column_lists.append(', '.join(i_d['column_names']))  # List[str] to nice comma sep string.
         uniques.append(i_d['unique'])
 
-        # Not doing anything with optional 'column_sorting' or 'dialect_options'
+        # Not doing anything with optional 'column_sorting' or 'dialect_options' at this time.
+        # (although column_sorting should be fairly easy to spice in)
 
     df = DataFrame({'Index': index_names, 'Columns': column_lists, 'Unique': uniques})
 
@@ -476,7 +463,12 @@ def index_dataframe(inspector: Inspector, table_name: str, schema: Optional[str]
 def set_dataframe_metadata(df: DataFrame, title=None) -> DataFrame:
     """Set noteable metadata in the dataframe for Dex to pick up"""
 
-    # This structure is expected to change.
+    # This is a stub for now. Expect a good number of additional kwargs to grow once
+    # Shoup / Noel and I get together.
+
+    # This structure is expected to change. And dx -> Dex doesn't notice any of these
+    # at this point in time, so this is a christmas list right now.
+
     df.attrs['noteable'] = {'defaults': {'title': title}}
 
     return df

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,8 @@ def populate_database(connection: Connection, include_comments=False):
         db.execute(
             'create table int_table(a int primary key not null, b int not null default 12, c int not null default 42)'
         )
+
+        db.execute('create unique index int_table_whole_row_idx on int_table(a,b,c)')
         db.execute('insert into int_table (a, b, c) values (1, 2, 3), (4, 5, 6)')
 
         db.execute(

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -285,7 +285,7 @@ class TestSingleRelationCommand:
         'handle,defaults_include_int8', [('@cockroach', True), ('@sqlite', False)]
     )
     def test_table_without_schema(
-        self, sql_magic, ipython_namespace, handle: str, defaults_include_int8: bool
+        self, sql_magic, ipython_namespace, handle: str, defaults_include_int8: bool, mock_display
     ):
         sql_magic.execute(fr'{handle} \describe int_table')
         results = ipython_namespace['_']
@@ -303,6 +303,24 @@ class TestSingleRelationCommand:
             expected_defaults = [None, '12', '42']
 
         assert results['Default'].tolist() == expected_defaults
+
+        # Two things will be display()ed ...
+        assert mock_display.call_count == 2
+
+        # 1) The dataframe describing the table columns.
+        df_displayed = mock_display.call_args_list[0].args[0]
+        assert isinstance(df_displayed, pd.DataFrame)
+        assert results is df_displayed
+
+        # 2) Dataframe describing the indices
+        index_df = mock_display.call_args_list[1].args[0]
+        assert isinstance(index_df, pd.DataFrame)
+        assert index_df.columns.tolist() == ['Index', 'Columns', 'Unique']
+        assert index_df['Index'][0] == 'int_table_whole_row_idx'
+        assert index_df['Columns'][0] == ['a', 'b', 'c']
+        assert index_df['Unique'][0] == True
+
+        assert index_df.attrs['noteable']['defaults']['title'] == 'Table "int_table" Indices'
 
     @pytest.mark.parametrize('invocation', [r'\describe', r'\d'])
     def test_varying_invocation(self, sql_magic, ipython_namespace, invocation: str):

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -317,8 +317,8 @@ class TestSingleRelationCommand:
         assert isinstance(index_df, pd.DataFrame)
         assert index_df.columns.tolist() == ['Index', 'Columns', 'Unique']
         assert index_df['Index'][0] == 'int_table_whole_row_idx'
-        assert index_df['Columns'][0] == ['a', 'b', 'c']
-        assert index_df['Unique'][0] == True
+        assert index_df['Columns'][0] == 'a, b, c'
+        assert index_df['Unique'][0] == True  # noqa: E712
 
         assert index_df.attrs['noteable']['defaults']['title'] == 'Table "int_table" Indices'
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Show a second datagframe describing the indices defined on a table when a table is `\describe`'d

