### PR TITLE
Presentation tweaks.

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -501,7 +501,7 @@ def defaults_get(df: DataFrame, attribute_path: str) -> Optional[str]:
     )  # "noteable.defaults.title" -> ['noteable', 'defaults', 'title']
     current = df.attrs
     for elem in elements:
-        if not elem in current:
+        if elem not in current:
             return None
 
         current = current[elem]

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -408,7 +408,7 @@ class SingleRelationCommand(MetaCommand):
                 display_view_name = displayable_relation_name(schema, relation_name)  # noqa: F841
                 html_buf = []
                 html_buf.append('<br />')
-                html_buf.append(f'<h2>View "{display_view_name}" Definition</h2>')
+                html_buf.append(f'<h2>View <code>{display_view_name}</code> Definition</h2>')
                 html_buf.append('<br />')
                 html_buf.append(f'<pre>{view_definition}</pre>')
 
@@ -418,7 +418,7 @@ class SingleRelationCommand(MetaCommand):
             # presentation.
             index_df = index_dataframe(inspector, relation_name, schema)
             if len(index_df):
-                display(index_df)
+                display(secondary_dataframe_to_html(index_df))
 
         return main_relation_df, False
 
@@ -448,14 +448,17 @@ def index_dataframe(inspector: Inspector, table_name: str, schema: Optional[str]
     for i_d in sorted(index_dicts, key=lambda d: d['name']):
         index_names.append(i_d['name'])
         column_lists.append(', '.join(i_d['column_names']))  # List[str] to nice comma sep string.
-        uniques.append(i_d['unique'])
+
+        # Was this index UNIQUE? Wackily, if we ask sqlite, it returns 0 or 1. CRDB at least
+        # returns expected boolean. So coerce to bool for consistency.
+        uniques.append(bool(i_d['unique']))
 
         # Not doing anything with optional 'column_sorting' or 'dialect_options' at this time.
         # (although column_sorting should be fairly easy to spice in)
 
     df = DataFrame({'Index': index_names, 'Columns': column_lists, 'Unique': uniques})
 
-    title = f'Table "{displayable_relation_name(schema, table_name)}" Indices'
+    title = f'Table <code>{displayable_relation_name(schema, table_name)}</code> Indices'
 
     return set_dataframe_metadata(df, title=title)
 
@@ -472,6 +475,38 @@ def set_dataframe_metadata(df: DataFrame, title=None) -> DataFrame:
     df.attrs['noteable'] = {'defaults': {'title': title}}
 
     return df
+
+
+def secondary_dataframe_to_html(df: DataFrame) -> HTML:
+    """Because DEX expects at most one dataframe directly display()ed from a cell
+    (the DEX control metadata is scoped singularly at the cell level), we cannot
+    differentiate titles, display style, etc. between multiple dataframes emitted
+    by a cell. So we need to hand-convert these additional datagframes down to
+    HTML explicitly.
+    """
+    html_buf = []
+    html_buf.append('<br />')
+    if title := defaults_get(df, 'noteable.defaults.title'):
+        html_buf.append(f'<h2>{title}</h2>')
+        html_buf.append('<br />')
+
+    html_buf.append(df.to_html(index=False))
+
+    return HTML('\n'.join(html_buf))
+
+
+def defaults_get(df: DataFrame, attribute_path: str) -> Optional[str]:
+    elements = attribute_path.split(
+        '.'
+    )  # "noteable.defaults.title" -> ['noteable', 'defaults', 'title']
+    current = df.attrs
+    for elem in elements:
+        if not elem in current:
+            return None
+
+        current = current[elem]
+
+    return current
 
 
 class HelpCommand(MetaCommand):
@@ -528,6 +563,7 @@ class HelpCommand(MetaCommand):
 
 
 def displayable_relation_name(schema: Optional[str], relation_name: str) -> str:
+    """If schema was specified, return dotted string. Otherwise just the relation name."""
     if schema:
         return f'{schema}.{relation_name}'
     else:

--- a/poetry.lock
+++ b/poetry.lock
@@ -114,14 +114,14 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.26.9"
+version = "1.26.12"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = ">=1.29.9,<1.30.0"
+botocore = ">=1.29.12,<1.30.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -130,7 +130,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.29.9"
+version = "1.29.12"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -540,17 +540,17 @@ requests = ["requests (>=2.18.0,<3.0.0dev)"]
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.56.4"
+version = "1.57.0"
 description = "Common protobufs used in Google APIs"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-protobuf = ">=3.15.0,<5.0.0dev"
+protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 
 [package.extras]
-grpc = ["grpcio (>=1.0.0,<2.0.0dev)"]
+grpc = ["grpcio (>=1.44.0,<2.0.0dev)"]
 
 [[package]]
 name = "greenlet"
@@ -592,11 +592,11 @@ protobuf = ">=4.21.6"
 
 [[package]]
 name = "h11"
-version = "0.12.0"
+version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "h2"
@@ -620,16 +620,16 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "httpcore"
-version = "0.15.0"
+version = "0.16.1"
 description = "A minimal low-level HTTP client."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-anyio = ">=3.0.0,<4.0.0"
+anyio = ">=3.0,<5.0"
 certifi = "*"
-h11 = ">=0.11,<0.13"
+h11 = ">=0.13,<0.15"
 sniffio = ">=1.0.0,<2.0.0"
 
 [package.extras]
@@ -638,7 +638,7 @@ socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.23.0"
+version = "0.23.1"
 description = "The next generation HTTP client."
 category = "main"
 optional = false
@@ -647,13 +647,13 @@ python-versions = ">=3.7"
 [package.dependencies]
 certifi = "*"
 h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
-httpcore = ">=0.15.0,<0.16.0"
+httpcore = ">=0.15.0,<0.17.0"
 rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
 sniffio = "*"
 
 [package.extras]
-brotli = ["brotlicffi", "brotli"]
-cli = ["click (>=8.0.0,<9.0.0)", "rich (>=10,<13)", "pygments (>=2.0.0,<3.0.0)"]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (>=8.0.0,<9.0.0)", "pygments (>=2.0.0,<3.0.0)", "rich (>=10,<13)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (>=1.0.0,<2.0.0)"]
 
@@ -822,7 +822,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "jupyter-client"
-version = "7.4.6"
+version = "7.4.7"
 description = "Jupyter protocol implementation and client libraries"
 category = "main"
 optional = false
@@ -2128,10 +2128,7 @@ googleapis-common-protos = []
 greenlet = []
 grpcio = []
 grpcio-status = []
-h11 = [
-    {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
-    {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
-]
+h11 = []
 h2 = [
     {file = "h2-4.1.0-py3-none-any.whl", hash = "sha256:03a46bcf682256c95b5fd9e9a99c1323584c3eec6440d379b9903d709476bc6d"},
     {file = "h2-4.1.0.tar.gz", hash = "sha256:a83aca08fbe7aacb79fec788c9c0bac936343560ed9ec18b82a13a12c28d2abb"},

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -312,15 +312,15 @@ class TestSingleRelationCommand:
         assert isinstance(df_displayed, pd.DataFrame)
         assert results is df_displayed
 
-        # 2) Dataframe describing the indices
-        index_df = mock_display.call_args_list[1].args[0]
-        assert isinstance(index_df, pd.DataFrame)
-        assert index_df.columns.tolist() == ['Index', 'Columns', 'Unique']
-        assert index_df['Index'][0] == 'int_table_whole_row_idx'
-        assert index_df['Columns'][0] == 'a, b, c'
-        assert index_df['Unique'][0] == True  # noqa: E712
-
-        assert index_df.attrs['noteable']['defaults']['title'] == 'Table "int_table" Indices'
+        # 2) HTML describing the indices
+        index_df_html = mock_display.call_args_list[1].args[0]
+        assert isinstance(index_df_html, HTML)
+        assert (
+            '<h2>Table <code>int_table</code> Indices</h2>' in index_df_html.data
+        )  # title was projected.
+        assert 'int_table_whole_row_idx' in index_df_html.data  # index name
+        assert 'a, b, c' in index_df_html.data  # index columns
+        assert 'True' in index_df_html.data  # is a unique index
 
     @pytest.mark.parametrize('invocation', [r'\describe', r'\d'])
     def test_varying_invocation(self, sql_magic, ipython_namespace, invocation: str):
@@ -361,7 +361,9 @@ class TestSingleRelationCommand:
         html_obj = mock_display.call_args_list[1].args[0]
         assert isinstance(html_obj, HTML)
         html_contents: str = html_obj.data
-        assert html_contents.startswith('<br />\n<h2>View "str_int_view" Definition</h2>')
+        assert html_contents.startswith(
+            '<br />\n<h2>View <code>str_int_view</code> Definition</h2>'
+        )
         # Some dialects include a 'CREATE VIEW' statement, others just start with 'select\n', and will vary by case.
         matcher = re.compile(
             '.*<pre>.*select.*s.str_id, s.int_col.*</pre>$',
@@ -379,7 +381,7 @@ class TestSingleRelationCommand:
         assert isinstance(html_obj, HTML)
         html_contents: str = html_obj.data
         assert html_contents.startswith(
-            '<br />\n<h2>View "public.str_int_view" Definition</h2>'
+            '<br />\n<h2>View <code>public.str_int_view</code> Definition</h2>'
         ), html_contents
 
     def test_no_args_gets_table_list(self, sql_magic, ipython_namespace):

--- a/tox.ini
+++ b/tox.ini
@@ -43,8 +43,10 @@ deps = safety
 whitelist_externals =
     poetry
     sh
+# Vulnerability ID: 51457 is against a corner of 'py', referenced by tox. See
+# https://github.com/tox-dev/tox/issues/2524
 commands =
-    sh -c "poetry export --without-hashes -f requirements.txt | safety check --stdin"
+    sh -c "poetry export --without-hashes -f requirements.txt | safety check --ignore=51457 --stdin"
 
 [testenv]
 whitelist_externals = poetry


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Presentation tweaks for the 'U' release discussed with @noteabledave :
  - DEX is not set up for single cells `display()`ing _multiple_ dataframes -- the display control metadata in the cell (like, say, 'title') is applied to all dataframes displayed by the cell. So, when describing indices of a table, err on the side of a hand-formatted HTML block instead of directly display()ing the dataframe. That way we can give it a distinguishing title so the user knows what they're seeing.
  - Emit table / view names in the HTML \<h2> title blocks within \<code> tags instead of either single or double quotes.

