### PR TITLE
Harden datasource bootstrapping -- do not let poison in one break ...

### DIFF
--- a/noteable_magics/logging.py
+++ b/noteable_magics/logging.py
@@ -48,7 +48,7 @@ def configure_logging(dev_logging: bool, ext_log_level, app_log_level) -> None:
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
-        cache_logger_on_first_use=True,
+        cache_logger_on_first_use=not dev_logging,
     )
 
     try:


### PR DESCRIPTION
bootstrapping others.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- If an exception happens while bootstrapping a datasource (possible with sufficiently garbage datasource details like a URL fragment provided instead of a hostname, confusing parsing deep in SQLA), catch exception, log, and move on. Do not let this one thing break bootstrapping other datasources or prevent the registration of the sql magic itself.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- A sufficiently broken datasource definition will prevent subsequent datasources from being bootstrapped, and then also prevent the SQL magic from completing its registration into ipykernel, making one think that the polymorph build is somehow lacking the sql magic.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Only the broken datasource will seem ignored / not present.
- Log events will be made, but these aren't surfaced to the user in any meaningful way (would be nice if they could be one day, or ... something).
