### PR TITLE
Datasource help display manual HTML table

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -85,7 +85,7 @@ class MetaCommand:
         # returning None, which gets handled later than this.
         self.shell.user_ns['_'] = df
 
-    def run(self, invoked_as: str, args: List[str]) -> Optional[Tuple[DataFrame, bool]]:
+    def run(self, invoked_as: str, args: List[str]) -> Tuple[DataFrame, bool]:
         """Implement the meta command.
 
         Subclass should return a pair of the 'primary' dataframe, and bool for if display() needs

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -88,9 +88,8 @@ class MetaCommand:
     def run(self, invoked_as: str, args: List[str]) -> Optional[Tuple[DataFrame, bool]]:
         """Implement the meta command.
 
-        Should either return a pair of the 'primary' dataframe, and bool for if display() needs
-        to be called with it or not. Otherwise return None and it it assumed that display()
-        has already been called on something which wasn't a dataframe to bind to a var.
+        Subclass should return a pair of the 'primary' dataframe, and bool for if display() needs
+        to be called with it or not.
         """
         raise NotImplementedError
 

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -63,15 +63,11 @@ class MetaCommand:
         self.assign_to_varname = assign_to_varname
 
     def do_run(self, invoked_as: str, args: List[str]):
-        maybe_tuple = self.run(invoked_as, args)
+        """Call down into subclass's `run()`, call `display()` if needed,
+        and assign to variable.
+        """
 
-        if not maybe_tuple:
-            # The command implementation didn't return anything. It must have
-            # taken care of displaying whatever it wanted itself. No variable
-            # assignments will happen.
-            return
-
-        df, need_display_call = maybe_tuple
+        df, need_display_call = self.run(invoked_as, args)
 
         if need_display_call:
             display(df)

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -446,6 +446,12 @@ class TestHelp:
         assert len(results) == len(_all_command_classes) - 1  # avoids talking about HelpCommand
         assert results.columns.tolist() == ['Command', 'Description', 'Documentation']
 
+        # Each description and documentation value should end with a period
+        for column in ['Description', 'Documentation']:
+            assert all(
+                value.endswith('.') for value in results[column]
+            ), f"{column} strings should be full sentences ending with a period: {[s for s in results[column] if not s.endswith('.')]}"
+
     # Both these specific commands should regurgitate the same help row.
     @pytest.mark.parametrize('cmdname', [r'\schemas', r'\dn+'])
     def test_single_topic_help(self, cmdname, sql_magic, ipython_namespace):
@@ -454,7 +460,7 @@ class TestHelp:
 
         assert len(results) == 1
         assert results.columns.tolist() == ['Command', 'Description', 'Documentation']
-        assert results['Description'][0] == 'List schemas (namespaces) within database'
+        assert results['Description'][0] == 'List schemas within database.'
         assert results['Command'][0] == r'\schemas, \schemas+, \dn, \dn+'
         assert results['Documentation'][0].startswith('List all the schemas')
 
@@ -485,8 +491,10 @@ class TestMisc:
 
         assert type(help_df) is pd.DataFrame
         assert help_df.columns.tolist() == ['Command', 'Description', 'Documentation']
+
+        # Will have displayed a prerendered HTML table of the help dataframe.
         assert (
-            'List all the relations (tables and views)' in out
+            '<IPython.core.display.HTML object>' in out
         )  # ... amoungst other things that \\help outputs!
 
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Have `\help` render its dataframe down to a HTML table and call `display()` directly with it, because DEX currently doesn't work well with these strings for a human-readable documentation purpose.
- Standardize punctuation in help contents.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- `\help` datagframe displayed poorly by DEX currently.
- `\help` contents phrasing is inconsistent.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- `\help` renders its dataframe down to a HTML table and call `display()` directly with it.
- Standardize punctuation in help messages.

## Future TODO
Have the single-command help text also include an example blurb showing usage examples. Ran out of time this sprint.