### PR TITLE
Better primary key index handling; try to get dataframes titled

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -482,6 +482,8 @@ def index_dataframe(
     # Primary key index is ... treated special by SQLA for some reason. Sigh.
     primary_index_dict = inspector.get_pk_constraint(table_name, schema)
 
+    # If it returned something truthy with nonempty constrained_columns, then
+    # we assume it described a real primary key constraint here.
     if primary_index_dict and primary_index_dict.get('constrained_columns'):
         unnamed_name = '(unnamed primary key)'
         # Is a little ambiguous if 'name' will _always_ be in the returned dict? In

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -378,8 +378,6 @@ class SingleRelationCommand(MetaCommand):
 
         schema, relation_name = self._split_schema_table(args[0])
 
-        displayable_rname = displayable_relation_name(schema, relation_name)
-
         inspector = self.get_inspector()
 
         is_view = relation_name in inspector.get_view_names(schema)
@@ -428,9 +426,12 @@ class SingleRelationCommand(MetaCommand):
         if any(comments):
             data['Comment'] = comments
 
+        displayable_rname = displayable_relation_name(schema, relation_name)
+
         main_relation_df = set_dataframe_metadata(
             DataFrame(data=data), title=f'{rtype} "{displayable_rname}" Structure'
         )
+
         display(main_relation_df)
 
         if is_view:

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -471,7 +471,7 @@ def index_dataframe(
     # Primary key index is ... treated special by SQLA for some reason. Sigh.
     primary_index_dict = inspector.get_pk_constraint(table_name, schema)
 
-    if primary_index_dict:
+    if primary_index_dict and primary_index_dict.get('constrained_columns'):
         unnamed_name = '(unnamed primary key)'
         # Is a little ambiguous if 'name' will _always_ be in the returned dict? In
         # sqlite it is, but returns None, so be double-delicate here.

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -291,7 +291,10 @@ def relation_names(
         # Only need to project this column if possibly displaying more than one kind of relation
         data['Kind'] = relation_types
 
-    return DataFrame(data), True
+    # Return dataframe and need to have display() called on it.
+    # (Not applying a title to the dataframe at this time because all of the possibilities
+    #  are currently daunting -- 'Views in Schema "public" Matching "v_*"' and whatnot.)
+    return (DataFrame(data), True)
 
 
 def parse_schema_and_relation_glob(
@@ -375,6 +378,8 @@ class SingleRelationCommand(MetaCommand):
 
         schema, relation_name = self._split_schema_table(args[0])
 
+        displayable_rname = displayable_relation_name(schema, relation_name)
+
         inspector = self.get_inspector()
 
         is_view = relation_name in inspector.get_view_names(schema)
@@ -387,6 +392,9 @@ class SingleRelationCommand(MetaCommand):
                 else:
                     msg = f'Relation {relation_name} does not exist'
                 raise MetaCommandException(msg)
+            rtype = 'Table'
+        else:
+            rtype = 'View'
 
         column_dicts = inspector.get_columns(relation_name, schema=schema)
 
@@ -420,7 +428,9 @@ class SingleRelationCommand(MetaCommand):
         if any(comments):
             data['Comment'] = comments
 
-        main_relation_df = DataFrame(data=data)
+        main_relation_df = set_dataframe_metadata(
+            DataFrame(data=data), title=f'{rtype} "{displayable_rname}" Structure'
+        )
         display(main_relation_df)
 
         if is_view:
@@ -505,10 +515,7 @@ def set_dataframe_metadata(df: DataFrame, title=None) -> DataFrame:
     # This is a stub for now. Expect a good number of additional kwargs to grow once
     # Shoup / Noel and I get together.
 
-    # This structure is expected to change. And dx -> Dex doesn't notice any of these
-    # at this point in time, so this is a christmas list right now.
-
-    df.attrs['noteable'] = {'defaults': {'title': title}}
+    df.attrs['noteable'] = {'decoration': {'title': title}}
 
     return df
 
@@ -522,7 +529,7 @@ def secondary_dataframe_to_html(df: DataFrame) -> HTML:
     """
     html_buf = []
     html_buf.append('<br />')
-    if title := defaults_get(df, 'noteable.defaults.title'):
+    if title := defaults_get(df, 'noteable.decoration.title'):
         html_buf.append(f'<h2>{title}</h2>')
         html_buf.append('<br />')
 
@@ -534,7 +541,7 @@ def secondary_dataframe_to_html(df: DataFrame) -> HTML:
 def defaults_get(df: DataFrame, attribute_path: str) -> Optional[str]:
     elements = attribute_path.split(
         '.'
-    )  # "noteable.defaults.title" -> ['noteable', 'defaults', 'title']
+    )  # "noteable.decoration.title" -> ['noteable', 'decoration', 'title']
     current = df.attrs
     for elem in elements:
         if elem not in current:

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -402,6 +402,18 @@ class TestSingleRelationCommand:
             '<br />\n<h2>View <code>public.str_int_view</code> Definition</h2>'
         ), html_contents
 
+    def test_against_table_without_a_primary_key(self, sql_magic, ipython_namespace, mock_display):
+        # str_table on sqlite will not have any primary key or any indices at all
+        # (all tables in cockroach have an implicit PK, so can't test with it)
+
+        # So the only output should be the dataframe. Not a subsequent HTML blob describing indices.
+        sql_magic.execute(r'@sqlite \d str_table')
+
+        assert len(mock_display.call_args_list) == 1
+
+        df = mock_display.call_args_list[0].args[0]
+        assert isinstance(df, pd.DataFrame)
+
     def test_no_args_gets_table_list(self, sql_magic, ipython_namespace):
         sql_magic.execute(r'@sqlite \d')
         results = ipython_namespace['_']

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -395,6 +395,9 @@ class TestSingleRelationCommand:
 
         sql_magic.execute(r'@cockroach \describe public.str_int_view')
 
+        df = mock_display.call_args_list[0].args[0]
+        assert df.attrs['noteable']['decoration']['title'] == 'View "public.str_int_view" Structure'
+
         html_obj = mock_display.call_args_list[1].args[0]
         assert isinstance(html_obj, HTML)
         html_contents: str = html_obj.data
@@ -412,6 +415,8 @@ class TestSingleRelationCommand:
         assert len(mock_display.call_args_list) == 1
 
         df = mock_display.call_args_list[0].args[0]
+        assert df.attrs['noteable']['decoration']['title'] == 'Table "str_table" Structure'
+
         assert isinstance(df, pd.DataFrame)
 
     def test_no_args_gets_table_list(self, sql_magic, ipython_namespace):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Stop being tricked by Inspector.get_pk_index() returning a nonempty dict but having no 'constrained_columns' members. That seems to be how it [undocumentedly](https://docs.sqlalchemy.org/en/14/core/reflection.html#sqlalchemy.engine.reflection.Inspector.get_pk_constraint) indicates 'there is no primary key here at all'.
- Switch the attrs structure to match what [dex and dx should start to honor](https://noteable-io.github.io/dx/plotting/overview/#using-pandas-dataframe-attrs) and title some of the returned dataframes.
- I'm aiming to include this in Vail.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- We think there are primary key constraints / indexes when really there aren't
- We don't describe dataframe attr titles in path that dex / dx will pick up and honor.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Stop lying about primary key indexes that don't exist
- Get some dataframes auto-titled when displayed by dex.
