### PR TITLE
Fix splitting/parsing to include doing the right thing with cell invo…

### DIFF
--- a/noteable_magics/sql/parse.py
+++ b/noteable_magics/sql/parse.py
@@ -8,7 +8,7 @@ def parse(cell, config) -> Dict[str, Optional[Union[str, bool]]]:
 
     result = {"connection": "", "sql": "", "result_var": None, 'skip_boxing_scalar_result': False}
 
-    pieces = cell.split(' ', 4)
+    pieces = cell.split(None, 4)
 
     if not pieces:
         return result

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -11,7 +11,7 @@ class TestSqlMagic:
         'invocation',
         [
             '@sqlite select a, b from int_table',  # as from line magic invocation
-            '@sqlite\nselect a, b from int_table',  # as from cell magic / Planar Ally
+            '@sqlite\nselect a, b\nfrom int_table',  # as from cell magic / Planar Ally
         ],
     )
     def test_basic_query(self, invocation, sql_magic, ipython_shell):


### PR DESCRIPTION
…cations coming from Planar Ally (ENG-5222)

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Planar Ally SQL cell invocations inject a \n in a place where we weren't testing for, and I had broken the parsing. This fixes and increases test coverage to include how Planar Ally will send over cell magic invocations.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- We break when presented with lines like `@noteable foo_df <<\nselect a, b from int_table` from Planar Ally. We don't tokenize the \n properly and the 'foo_df <<' portion ends up being sent down as SQL to the database, causing hilarity.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Going back to doing the right thing, hopefully, supporting both variable assignement as well as #scalar pragma/directive handling.
