### PR TITLE
Eng 5268 fix sql cell create table

### DIFF
--- a/noteable_magics/sql/run.py
+++ b/noteable_magics/sql/run.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import pandas as pd
 import sqlalchemy
@@ -11,32 +11,69 @@ class ResultSet:
     Results of a SQL query.
     """
 
+    # Result of a SELECT or perhaps INSERT INTO ... RETURNING projecting a result set.
+    keys: Optional[List[str]] = None
+    rows: Optional[list] = None
+
+    # In case of an INSERT, UPDATE, or DELETE statement.
+    rowcount: Optional[int] = None
+
+    has_results_to_report: bool = True
+
     def __init__(self, sqla_result, sql, config):
-        self.keys: List[str] = list(sqla_result.keys())
-        self.rows: list = sqla_result.fetchall()
+        if sqla_result.returns_rows:
+            self.keys = list(sqla_result.keys())
+            self.rows = sqla_result.fetchall()
+        elif sqla_result.rowcount != -1:
+            # Was either DDL or perhaps DML like an INSERT or UPDATE statement
+            # that just talks about number or rows affected server-side.
+            self.rowcount = sqla_result.rowcount
+        else:
+            # CREATE TABLE or somesuch DDL that ran successfully and offers
+            # no constructive feedback whatsoever.
+            self.has_results_to_report = False
 
     @property
     def is_scalar_value(self) -> bool:
-        return len(self.rows) == 1 and len(self.rows[0]) == 1
+        return self.has_results_to_report and (
+            (self.rowcount is not None) or (len(self.rows) == 1 and len(self.rows[0]) == 1)
+        )
 
     @property
     def scalar_value(self):
-        """Return the only row / column value as bare scalar"""
+        """Return either the only row / column value, or the affected num of rows
+        from an INSERT/DELETE/UPDATE statement as bare scalar"""
 
         # Should only be called if self.is_scalar_value
-        return self.rows[0][0]
+        if self.rowcount is not None:
+            return self.rowcount
+        else:
+            return self.rows[0][0]
 
-    def to_dataframe(self) -> pd.DataFrame:
-        "Returns a Pandas DataFrame instance built from the result set."
+    @property
+    def can_become_dataframe(self) -> bool:
+        return self.has_results_to_report and self.rows is not None
 
-        return pd.DataFrame(self.rows, columns=(self.rows and self.keys) or [])
+    def to_dataframe(self) -> Optional[pd.DataFrame]:
+        "Returns a Pandas DataFrame instance built from the result set, if possible."
+
+        # Should only be called if self.can_become_dataframe is True
+
+        # Worst case will be a zero row but defined columns dataframe.
+        return pd.DataFrame(self.rows, columns=self.keys)
 
 
 def interpret_rowcount(rowcount):
     if rowcount < 0:
         result = "Done."
     else:
-        result = "%d rows affected." % rowcount
+        if rowcount != 1:
+            noun = 'rows'
+        else:
+            noun = 'row'
+
+        result = f"{rowcount} {noun} affected."
+
     return result
 
 
@@ -91,12 +128,19 @@ def run(conn, sql, config, user_namespace, skip_boxing_scalar_result: bool):
             result = conn.session.execute(txt, bind_params)
 
             _commit(conn=conn, config=config)
+
             if result and config.feedback:
                 print(interpret_rowcount(result.rowcount))
 
         resultset = ResultSet(result, statement, config)
 
-        if skip_boxing_scalar_result and resultset.is_scalar_value:
-            return resultset.scalar_value
-        else:
-            return resultset.to_dataframe()
+        if resultset.has_results_to_report:
+            if resultset.can_become_dataframe:
+                if skip_boxing_scalar_result and resultset.is_scalar_value:
+                    return resultset.scalar_value
+                else:
+                    return resultset.to_dataframe()
+            else:
+                # Must have been INSERT/UPDATE/DELETE statement
+                # just returning a rowcount.
+                return resultset.rowcount

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,8 @@ from noteable_magics.planar_ally_client.types import (
 )
 from noteable_magics.sql.connection import Connection
 from noteable_magics.sql.magic import SqlMagic
+from noteable_magics.sql.run import add_commit_blacklist_dialect
+
 
 # managed_service_fixtures plugin for a live cockroachdb
 pytest_plugins = 'managed_service_fixtures'
@@ -211,6 +213,9 @@ def cockroach_database_connection(managed_cockroach: CockroachDetails) -> Tuple[
     from noteable_magics.datasource_postprocessing import _install_psycopg2_interrupt_fix
 
     _install_psycopg2_interrupt_fix()
+
+    # CRDB will by default be in autocommit mode, so must prevent trying to double-commit.
+    add_commit_blacklist_dialect('cockroachdb')
 
     handle = '@cockroach'
     human_name = "My Cockroach Connection"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ from noteable_magics.sql.connection import Connection
 from noteable_magics.sql.magic import SqlMagic
 from noteable_magics.sql.run import add_commit_blacklist_dialect
 
-
 # managed_service_fixtures plugin for a live cockroachdb
 pytest_plugins = 'managed_service_fixtures'
 

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -2,11 +2,11 @@
 
 
 from pathlib import Path
+from uuid import uuid4
 
 import pandas as pd
 import pytest
 import requests
-from uuid import uuid4
 
 from noteable_magics import datasources
 from tests.conftest import DatasourceJSONs

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -71,6 +71,16 @@ class TestSqlMagic:
         results = sql_magic.execute('@sqlite #scalar select a from int_table')
         assert isinstance(results, pd.DataFrame)
 
+    def test_select_no_rows_from_table_produces_zero_row_dataframe_with_expected_columns(
+        self, sql_magic
+    ):
+        # Will match 0 rows, but should be returned as 0-row three-column'd dataframe.
+        results = sql_magic.execute('@sqlite select a, b, c from int_table where a = -12')
+
+        assert isinstance(results, pd.DataFrame)
+        assert len(results) == 0
+        assert results.columns.tolist() == ['a', 'b', 'c']
+
     @pytest.mark.parametrize(
         'invocation',
         [


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix DDL commands like 'CREATE TABLE,' etc. Got broken somewhere within most recent [PR-62](https://github.com/noteable-io/noteable-notebook-magics/pull/62), on staging but not in production yet because there were no automated tests over DDL. Now gots 'em.
- While here, make it so that the assigned cell result coming from statements that only return a rowcount, like 'DELETE from foo where id in (1, 5, 7, 9)' will be that affected rowcount -- say, an integer 4 in this case.
- Also test that we behave more like a SQL client in face of a SELECT statement that matches no rows, which is to produce _a properly column'd but zero-length dataframe_. **This portion may or may not be controversial**. We might actually like / prefer the existing behavior of having such a result just be None, not a degenerate dataframe?

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- CREATE / INSERT / DELETE etc. statements that do not return a proper result set cause SQL cell exceptions.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- CREATE / INSERT / DELETE etc. statements that do not return a proper result work again.
- If the statement affected a finite number of rows (like, say a DELETE / INSERT / UPDATE' statement w/o a 'RETURNING' clause, then the number of affected rows will be the cell return result.
- A SELECT statement that matches zero rows will now return a dataframe describing the rows, instead of just returning None. 
