### PR TITLE
Fix \describe vs tables with PGish uuid columns, ENG-5254.

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -405,8 +405,15 @@ class SingleRelationCommand(MetaCommand):
 
         for col in column_dicts:
             names.append(col['name'])
+
             # Convert the possibly db-centric TypeEngine instance to a sqla-generic type string
-            types.append(str(col['type'].as_generic()).lower())
+            try:
+                type_name = str(col['type'].as_generic()).lower()
+            except NotImplementedError:
+                # ENG-5268: More esoteric types like UUID do not implement .as_generic()
+                type_name = str(col['type']).replace('()', '').lower()
+
+            types.append(type_name)
             nullables.append(col['nullable'])
             defaults.append(col['default'])
             if 'comment' in col:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- The SQLAlchemy-side type descriptor object returned when introspecting into a PG-ish uuid column does not implement the `as_generic()` method all of the prior encountered data types do. So catch an exception, and stringify it a different way.
- While here and needing to have the test suite create a table in CRDB just for this one test, adjust the fixtures so that any newly created tables within a test will be automatically dropped.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Cannot `\describe` a table that has a UUID column. Like, oh, any from reproductions of our gate database.
- Tests in this test suite must be sure to clean up their own newly created tables otherwise will break some of the downstream introspection tests.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Can now introspect into uuid-column-containing tables / views.
- Test fixtures clean up any within-test created tables or views.
