### PR TITLE
Describe outbound foreign keys in SQL Cell \describe output.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,10 +200,14 @@ def cleanup_any_extra_tables(connection: Connection):
 
     unexpected_relations = relations - KNOWN_TABLES
 
+    # CRDB needs 'cascade' to be able to drop tables referenced with FKs. SQLite does
+    # not recognize, however.
+    maybe_cascade = 'cascade' if 'cockroach' in str(connection._engine) else ''
+
     for unexpected_relation in unexpected_relations:
         try:
             with Session(connection._engine) as db:
-                db.execute(f'drop table {unexpected_relation}')
+                db.execute(f'drop table {unexpected_relation} {maybe_cascade}')
                 db.commit()
         except Exception:
             # Maybe it was a view?


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Teach SQL Cell `\describe <table_name>` to dig up information about the outbound foreign keys constraining columns in <table_name>. Handles compound (multi-column) foreign keys. Will display the results as a HTML table similar to how indexes are displayed.


Single simple FK:
----
<h2>Table <code>references_int_table</code> Foreign Keys</h2>
<br />
<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th>Foreign Key</th>
      <th>Columns</th>
      <th>Referenced Table</th>
      <th>Referenced Columns</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>references_int_table_a_id_fkey</td>
      <td>a_id</td>
      <td>int_table</td>
      <td>a</td>
    </tr>
  </tbody>
</table>


Single compound FK:
----

<h2>Table <code>references_int_table_2</code> Foreign Keys</h2>
<br />
<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th>Foreign Key</th>
      <th>Columns</th>
      <th>Referenced Table</th>
      <th>Referenced Columns</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>a_b_fk</td>
      <td>a_ref, b_ref</td>
      <td>int_table_2</td>
      <td>a, b</td>
    </tr>
  </tbody>
</table>
