### PR TITLE
Eng 5335 sql cell describe to enumerate constraints

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -493,7 +493,7 @@ def constraints_dataframe(
 
     constraint_dicts: List[dict] = inspector.get_check_constraints(table_name, schema)
 
-    for constraint_dict in constraint_dicts:
+    for constraint_dict in sorted(constraint_dicts, key=lambda d: d['name']):
         names.append(constraint_dict['name'])
         definitions.append(constraint_dict['sqltext'])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,10 +158,17 @@ def populate_database(connection: Connection, include_comments=False):
         db.execute('insert into int_table (a, b, c) values (1, 2, 3), (4, 5, 6)')
 
         db.execute(
-            "create table str_table(str_id text not null default 'foonly', int_col int default 22)"
+            """create table str_table(
+                str_id text not null default 'f'
+                    constraint single_char_str_id check (length(str_id) = 1),
+                int_col int default 22
+                    constraint only_even_int_col_values check (int_col % 2 = 0),
+                constraint never_f_10 check (not (str_id = 'f' and int_col = 10))
+             )
+            """
         )
         db.execute(
-            "insert into str_table(str_id, int_col) values ('a', 1), ('b', 2), ('c', 3), ('d', null)"
+            "insert into str_table(str_id, int_col) values ('a', 2), ('b', 2), ('c', 4), ('d', null)"
         )
 
         db.execute(

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -233,7 +233,7 @@ class TestJinjaTemplatesWithinSqlMagic:
         )
 
         # Scalar result.
-        assert results == 1
+        assert results == 2
 
     @pytest.mark.parametrize('ret_col,expected_value', [('a', 1), ('b', 2)])
     def test_sqlsafe(self, sql_magic, ipython_shell, ret_col, expected_value):

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -549,9 +549,9 @@ class TestSingleRelationCommand:
 
         # This one happens to be regurgitated consistently between sqlite and CRDB.
         assert 'length(str_id) = 1' in constraint_definitions
-        # Little gentler for the other two.
-        assert any("str_id = 'f'" in cd.lower() for cd in constraint_definitions)
-        assert any("int_col % 2" in cd.lower() for cd in constraint_definitions)
+        # Little gentler substring matching for the other two.
+        assert any("str_id = 'f'" in cd for cd in constraint_definitions)
+        assert any("int_col % 2" in cd for cd in constraint_definitions)
 
     def test_no_args_gets_table_list(self, sql_magic, ipython_namespace):
         sql_magic.execute(r'@sqlite \d')

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -536,14 +536,22 @@ class TestSingleRelationCommand:
             'Definition',
         ]
 
-        assert sorted(constraint_df['Constraint'].tolist()) == sorted(
-            ('never_f_10', 'single_char_str_id', 'only_even_int_col_values')
-        )
+        # Should be alpha sorted by constraint name.
+        assert constraint_df['Constraint'].tolist() == [
+            'never_f_10',
+            'only_even_int_col_values',
+            'single_char_str_id',
+        ]
 
         # The SQL dialects convert the constraint expressions back to strings with slightly
-        # varying spellings (as expected), so can't simply blindly assert. But this one happens
-        # to be regurgitated consistently between sqlite and CRDB.
-        assert 'length(str_id) = 1' in constraint_df['Definition'].tolist()
+        # varying spellings (as expected), so can't simply blindly assert all of them.
+        constraint_definitions = constraint_df['Definition'].tolist()
+
+        # This one happens to be regurgitated consistently between sqlite and CRDB.
+        assert 'length(str_id) = 1' in constraint_definitions
+        # Little gentler for the other two.
+        assert any("str_id = 'f'" in cd.lower() for cd in constraint_definitions)
+        assert any("int_col % 2" in cd.lower() for cd in constraint_definitions)
 
     def test_no_args_gets_table_list(self, sql_magic, ipython_namespace):
         sql_magic.execute(r'@sqlite \d')

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -503,7 +503,7 @@ class TestSingleRelationCommand:
         # because will be returned and should not be talking about primary key / indices.
         constraint_html = mock_display.call_args_list[1].args[0].data
         assert constraint_html.startswith(
-            '<br />\n<h2>Table <code>str_table</code> Constraints</h2>'
+            '<br />\n<h2>Table <code>str_table</code> Check Constraints</h2>'
         )
 
     # All CRDB tables have a primary key, so conditionally expect it to be described.


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Display check constraints defined on a table when `\describe`ing it. Sample:

<h2>Table <code>str_table</code> Check Constraints</h2>
<br />
<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th>Constraint</th>
      <th>Definition</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>never_f_10</td>
      <td>NOT ((str_id = 'f'::STRING) AND (int_col = 10))</td>
    </tr>
    <tr>
      <td>only_even_int_col_values</td>
      <td>(int_col % 2) = 0</td>
    </tr>
    <tr>
      <td>single_char_str_id</td>
      <td>length(str_id) = 1</td>
    </tr>
  </tbody>
</table>