### PR TITLE
Simplify titles of secondary metadata HTML tables.

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -449,7 +449,7 @@ class SingleRelationCommand(MetaCommand):
                 display_view_name = displayable_relation_name(schema, relation_name)  # noqa: F841
                 html_buf = []
                 html_buf.append('<br />')
-                html_buf.append(f'<h2>View <code>{display_view_name}</code> Definition</h2>')
+                html_buf.append('<h2>View Definition</h2>')
                 html_buf.append('<br />')
                 html_buf.append(f'<pre>{view_definition}</pre>')
 
@@ -504,9 +504,7 @@ def constraints_dataframe(
         }
     )
 
-    title = f'Table <code>{displayable_relation_name(schema, table_name)}</code> Check Constraints'
-
-    return set_dataframe_metadata(df, title=title)
+    return set_dataframe_metadata(df, title='Check Constraints')
 
 
 def foreignkeys_dataframe(
@@ -542,9 +540,7 @@ def foreignkeys_dataframe(
         }
     )
 
-    title = f'Table <code>{displayable_relation_name(schema, table_name)}</code> Foreign Keys'
-
-    return set_dataframe_metadata(df, title=title)
+    return set_dataframe_metadata(df, title='Foreign Keys')
 
 
 def index_dataframe(
@@ -584,9 +580,7 @@ def index_dataframe(
 
     df = DataFrame({'Index': index_names, 'Columns': column_lists, 'Unique': uniques})
 
-    title = f'Table <code>{displayable_relation_name(schema, table_name)}</code> Indices'
-
-    return set_dataframe_metadata(df, title=title)
+    return set_dataframe_metadata(df, title='Indexes')
 
 
 def set_dataframe_metadata(df: DataFrame, title=None) -> DataFrame:

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -439,7 +439,7 @@ class TestSingleRelationCommand:
         assert isinstance(fk_html, HTML)
         html_contents: str = fk_html.data
 
-        assert html_contents.startswith(f'<br />\n<h2>Foreign Keys</h2>'), html_contents
+        assert html_contents.startswith('<br />\n<h2>Foreign Keys</h2>'), html_contents
 
         # Convert the HTML table back to dataframe to complete test.
         fk_df = pd.read_html(html_contents)[0]

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -324,9 +324,7 @@ class TestSingleRelationCommand:
         # 2) HTML describing the indices
         index_df_html = mock_display.call_args_list[1].args[0]
         assert isinstance(index_df_html, HTML)
-        assert (
-            '<h2>Table <code>int_table</code> Indices</h2>' in index_df_html.data
-        )  # title was projected.
+        assert '<h2>Indexes</h2>' in index_df_html.data  # title was projected.
 
         # Convert the HTML spelling of the indices back into a DF to test the output.
         df_from_index_html = pd.read_html(index_df_html.data)[0]
@@ -380,9 +378,7 @@ class TestSingleRelationCommand:
         html_obj = mock_display.call_args_list[1].args[0]
         assert isinstance(html_obj, HTML)
         html_contents: str = html_obj.data
-        assert html_contents.startswith(
-            '<br />\n<h2>View <code>str_int_view</code> Definition</h2>'
-        )
+        assert html_contents.startswith('<br />\n<h2>View Definition</h2>')
         # Some dialects include a 'CREATE VIEW' statement, others just start with 'select\n', and will vary by case.
         matcher = re.compile(
             '.*<pre>.*select.*s.str_id, s.int_col.*</pre>$',
@@ -420,9 +416,7 @@ class TestSingleRelationCommand:
         html_obj = mock_display.call_args_list[1].args[0]
         assert isinstance(html_obj, HTML)
         html_contents: str = html_obj.data
-        assert html_contents.startswith(
-            '<br />\n<h2>View <code>public.str_int_view</code> Definition</h2>'
-        ), html_contents
+        assert html_contents.startswith('<br />\n<h2>View Definition</h2>'), html_contents
 
     @pytest.mark.parametrize(
         'handle,schema', [('@cockroach', ''), ('@cockroach', 'public'), ('@sqlite', '')]
@@ -445,9 +439,7 @@ class TestSingleRelationCommand:
         assert isinstance(fk_html, HTML)
         html_contents: str = fk_html.data
 
-        assert html_contents.startswith(
-            f'<br />\n<h2>Table <code>{qualified_references_int_table}</code> Foreign Keys</h2>'
-        ), html_contents
+        assert html_contents.startswith(f'<br />\n<h2>Foreign Keys</h2>'), html_contents
 
         # Convert the HTML table back to dataframe to complete test.
         fk_df = pd.read_html(html_contents)[0]
@@ -502,9 +494,7 @@ class TestSingleRelationCommand:
         # Test test_constraints() will exercise this further. Only mention it here
         # because will be returned and should not be talking about primary key / indices.
         constraint_html = mock_display.call_args_list[1].args[0].data
-        assert constraint_html.startswith(
-            '<br />\n<h2>Table <code>str_table</code> Check Constraints</h2>'
-        )
+        assert constraint_html.startswith('<br />\n<h2>Check Constraints</h2>')
 
     # All CRDB tables have a primary key, so conditionally expect it to be described.
     @pytest.mark.parametrize(
@@ -522,9 +512,7 @@ class TestSingleRelationCommand:
 
         # The constraints HTML blob will be the final one always.
         constraint_html = mock_display.call_args_list[-1].args[0].data
-        assert constraint_html.startswith(
-            '<br />\n<h2>Table <code>str_table</code> Check Constraints</h2>'
-        )
+        assert constraint_html.startswith('<br />\n<h2>Check Constraints</h2>')
 
         # Convert back to dataframe
         constraint_df = pd.read_html(constraint_html)[0]


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Simplify the \<h2> title contents of the secondary dataframes-as-html being displayed by SQL cell metadata commands like \describe and so on. The main dataframe displayed by dex (the table / view structure) will be titled something like 'Table `\<tablename>` Definition', setting a clear enough stage so that the subsequent cell outputs can just be titled 'Indexes', 'Foreign Keys', 'Check Constraints' instead of repeating 'Table <table_name>' over and over. Now that we include describing foreign keys and check constraints the repetition was heavy handed. 

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Repeatedly say 'Table <table_name>' in the \<h2> elements titling the next set of metadata for the table. The repetition is unnecessary.

<img width="960" alt="Screen Shot 2023-01-04 at 4 04 38 PM" src="https://user-images.githubusercontent.com/1128313/210809095-72d0fa64-daa9-4990-8d0a-d2fbd937aee1.png">


## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Just say 'Indexes', 'Foreign Keys', or 'Check Constraints'. Also get off high-horse and use term 'indexes' and not 'indices'.
