### PR TITLE
Drive full introspsection and reporting back to gate via SQL cell \introspect

### DIFF
--- a/noteable_magics/sql/gate_messaging_types.py
+++ b/noteable_magics/sql/gate_messaging_types.py
@@ -1,0 +1,160 @@
+# Declare the message types
+
+import enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, root_validator
+
+r"""
+Messaging types used for SQL cell meta command \introspect when describing
+the structure of a discovered table or view up to Gate for permanent storage for
+front-end GUI schema navigation uses.
+
+These types culminating in RelationStructureDescription are inputs to the Gate
+POST route(s).
+"""
+
+
+@enum.unique
+class RelationKind(str, enum.Enum):
+    """Enumeration differentating between tables and views"""
+
+    table = "table"
+    view = "view"
+
+    class Config:
+        extra = "forbid"
+
+
+class ColumnModel(BaseModel):
+    """Pydantic model defining a column of an introspected table or view.
+
+    Used in two contexts:
+       * SQLAlchemy validation prior to assigning new value into DatasourceRelationDAO.columns JSONB column
+       * Subcomponent of upcoming pydantic model(s) used for route I/O (ENG-5356, ENG-5359).
+    """
+
+    name: str
+    is_nullable: bool
+    data_type: str
+    default_expression: Optional[str] = None
+    comment: Optional[str] = None
+
+    class Config:
+        extra = "forbid"
+
+
+class IndexModel(BaseModel):
+    """Pydantic model defining an introspected index.
+
+    Used in two contexts:
+       * SQLAlchemy validation prior to assigning new value into DatasourceRelationDAO.indexes JSONB column
+       * Subcomponent of upcoming pydantic models used for route I/O (ENG-5356, ENG-5359).
+    """
+
+    name: str
+    is_unique: bool
+    columns: List[str]
+
+    class Config:
+        extra = "forbid"
+
+
+class UniqueConstraintModel(BaseModel):
+    """Pydantic model defining an introspected unique constraint.
+
+    Used in two contexts:
+       * SQLAlchemy validation prior to assigning new value into DatasourceRelationDAO.unique_constraints JSONB column
+       * Subcomponent of upcoming pydantic models used for route I/O (ENG-5356, ENG-5359).
+    """
+
+    name: str
+    columns: List[str]
+
+    class Config:
+        extra = "forbid"
+
+
+class CheckConstraintModel(BaseModel):
+    """Pydantic model defining an introspected check constraint.
+
+    Used in two contexts:
+       * SQLAlchemy validation prior to assigning new value into DatasourceRelationDAO.check_constraints JSONB column
+       * Subcomponent of upcoming pydantic models used for route I/O (ENG-5356, ENG-5359).
+    """
+
+    name: str
+    expression: str
+
+    class Config:
+        extra = "forbid"
+
+
+class ForeignKeysModel(BaseModel):
+    """Pydantic model defining an introspected foreign key constraint.
+
+    Used in two contexts:
+       * SQLAlchemy validation prior to assigning new value into DatasourceRelationDAO.foreign_keys JSONB column
+       * Subcomponent of upcoming pydantic models used for route I/O (ENG-5356, ENG-5359).
+    """
+
+    name: str
+    referenced_schema: str
+    referenced_relation: str
+    columns: List[str]
+    referenced_columns: List[str]
+
+    @root_validator
+    def check_lists_same_length(cls, values):
+        if not ("columns" in values and "referenced_columns" in values):
+            raise ValueError("columns and referenced_columns required")
+
+        if len(values["columns"]) != len(values["referenced_columns"]):
+            raise ValueError("columns and referenced_columns must be same length")
+
+        return values
+
+    class Config:
+        extra = "forbid"
+
+
+class RelationStructureDescription(BaseModel):
+    """Pydantic model describing the POST structure kernel-space will use to describe a
+    schema-discovered table or view within a datasource.
+    """
+
+    # First, the singular fields.
+    schema_name: str = Field(
+        description="Name of schema containing the relation. Empty string for degenerate value."
+    )
+    relation_name: str = Field(description="Name of the table or view")
+    kind: RelationKind = Field(description="Relation type: table or a view")
+    relation_comment: Optional[str] = Field(description="Optional comment describing the relation.")
+    view_definition: Optional[str] = Field(description="Definition of the view if kind=view")
+    primary_key_name: Optional[str] = Field(description="Name of the primary key constraint")
+
+    # Now the plural fields.
+    primary_key_columns: List[str] = Field(
+        description="List of column names comprising the primary key, if any."
+    )
+    columns: List[ColumnModel] = Field(description="List of column definitions")
+    indexes: List[IndexModel] = Field(description="List of index definitions")
+    unique_constraints: List[UniqueConstraintModel] = Field(
+        description="List of unique constraint definitions"
+    )
+    check_constraints: List[CheckConstraintModel] = Field(
+        description="List of check constraint definitions"
+    )
+    foreign_keys: List[ForeignKeysModel] = Field(description="List of foreign key definitions")
+
+    @root_validator
+    def view_definition_vs_kind(cls, values):
+        if not (values.get("view_definition") is None) == (
+            values.get("kind") == RelationKind.table
+        ):
+            raise ValueError("Views require definitions, tables must not have view definition")
+
+        return values
+
+    class Config:
+        extra = "forbid"

--- a/noteable_magics/sql/gate_messaging_types.py
+++ b/noteable_magics/sql/gate_messaging_types.py
@@ -151,6 +151,11 @@ class RelationStructureDescription(BaseModel):
 
     @root_validator
     def view_definition_vs_kind(cls, values):
+        """Fail if a tring to describe a view with None for the view definition. At worst
+        empty string is allowed.
+
+        Likewise, if describing a table, then view definition _must_ be None.
+        """
         if not (values.get("view_definition") is None) == (
             values.get("kind") == RelationKind.table
         ):

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -511,6 +511,8 @@ class IntrospectAndStoreDatabaseCommand(MetaCommand):
 
     include_in_help = False
 
+    MAX_INTROSPECTION_THREADS = 10
+
     # Schemas to never introspect into.
     avoid_schemas = set(('information_schema', 'pg_catalog', 'crdb_internal'))
 
@@ -761,7 +763,7 @@ class IntrospectAndStoreDatabaseCommand(MetaCommand):
 
         # Introspect each relation concurrently.
         # TODO: Take concurrency as a param?
-        with ThreadPoolExecutor(max_workers=5) as executor:
+        with ThreadPoolExecutor(max_workers=self.MAX_INTROSPECTION_THREADS) as executor:
 
             future_to_relation = {
                 executor.submit(

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -9,7 +9,7 @@ import pytest
 import requests
 
 from noteable_magics import datasources
-from tests.conftest import DatasourceJSONs
+from tests.conftest import COCKROACH_HANDLE, DatasourceJSONs
 
 
 @pytest.mark.usefixtures("populated_sqlite_database")
@@ -153,7 +153,7 @@ class TestSqlMagic:
 
 @pytest.mark.usefixtures("populated_cockroach_database", "populated_sqlite_database")
 class TestDDLStatements:
-    @pytest.mark.parametrize('conn_name', ['@sqlite', '@cockroach'])
+    @pytest.mark.parametrize('conn_name', ['@sqlite', COCKROACH_HANDLE])
     def test_ddl_lifecycle(self, conn_name: str, sql_magic, capsys):
         table_name = f'test_table_{uuid4().hex}'
 
@@ -177,7 +177,7 @@ class TestDDLStatements:
         captured = capsys.readouterr()
         assert captured.out == 'Done.\n2 rows affected.\n1 row affected.\n'
 
-    @pytest.mark.parametrize('conn_name', ['@cockroach'])
+    @pytest.mark.parametrize('conn_name', [COCKROACH_HANDLE])
     def test_insert_returning_returns_dataframe(self, conn_name: str, sql_magic):
         table_name = f'test_table_{uuid4().hex}'
 

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -651,6 +651,7 @@ class TestFullIntrospection:
                 if from_json.primary_key_name and from_json.primary_key_columns:
                     had_primary_key_columns = True
                 else:
+                    #
                     assert (
                         from_json.primary_key_name is None and from_json.primary_key_columns == []
                     )
@@ -675,6 +676,16 @@ class TestFullIntrospection:
         assert had_unique_constraints
         assert had_check_constraints
         assert had_foreign_keys
+
+    @pytest.mark.usefixtures("populated_sqlite_database")
+    def test_cannot_introspect_legacy_datasource(self, sql_magic, capsys):
+        r"""Only datasource-uuid-based connections should be \introspect fodder"""
+
+        sql_magic.execute(r'@sqlite \introspect')
+        out, err = capsys.readouterr()
+
+        assert err == 'Cannot introspect into this resource.\n'
+        assert out == ''
 
 
 @pytest.mark.usefixtures("populated_sqlite_database")

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -650,6 +650,10 @@ class TestFullIntrospection:
 
                 if from_json.primary_key_name and from_json.primary_key_columns:
                     had_primary_key_columns = True
+                else:
+                    assert (
+                        from_json.primary_key_name is None and from_json.primary_key_columns == []
+                    )
 
                 if from_json.columns:
                     had_columns = True

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -639,10 +639,9 @@ class TestFullIntrospection:
 
         for req in patched_requests_mock.request_history:
             if req.method == 'POST' and req.url.endswith('/schema/relation'):
-                posted_json = req.json()
 
-                # Should correspond to RelationStructureDescription
-                from_json = RelationStructureDescription(**posted_json)
+                # POST body should correspond to RelationStructureDescription describing a single relation.
+                from_json = RelationStructureDescription(**req.json())
                 described_relation_names.add(from_json.relation_name)
 
                 if from_json.indexes:

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -693,19 +693,7 @@ class TestRelationStructure:
 
     def test_success_no_primary_key(self):
         # primary_key_name=None is how to describe no primary key / columns.
-        RelationStructureDescription(
-            schema_name='foo',
-            relation_name='bar',
-            kind='table',
-            primary_key_name=None,
-            primary_key_columns=[],
-            # rest is uninteresting for the test.
-            columns=[],
-            indexes=[],
-            unique_constraints=[],
-            check_constraints=[],
-            foreign_keys=[],
-        )
+        self.try_cons(primary_key_name=None, primary_key_columns=[])
 
     @pytest.mark.parametrize('pkey_name', ['', 'foo_pkey'])
     def test_fail_primary_key_no_primary_key_columns(self, pkey_name):
@@ -713,45 +701,30 @@ class TestRelationStructure:
         with pytest.raises(
             ValueError, match="No primary_key_columns requires primary_key_name = None"
         ):
-            RelationStructureDescription(
-                schema_name='foo',
-                relation_name='bar',
-                kind='table',
-                primary_key_name=pkey_name,
-                primary_key_columns=[],
-                # rest is uninteresting for the test.
-                columns=[],
-                indexes=[],
-                unique_constraints=[],
-                check_constraints=[],
-                foreign_keys=[],
-            )
+            self.try_cons(primary_key_name=pkey_name, primary_key_columns=[])
 
     def test_fail_primary_key_columns_no_primary_key_name(self):
         with pytest.raises(
             ValueError, match="primary_key_columns requires nonempty primary_key_name"
         ):
-            RelationStructureDescription(
-                schema_name='foo',
-                relation_name='bar',
-                kind='table',
-                primary_key_name=None,
-                primary_key_columns=['id'],
-                # rest is uninteresting for the test.
-                columns=[],
-                indexes=[],
-                unique_constraints=[],
-                check_constraints=[],
-                foreign_keys=[],
-            )
+            self.try_cons(primary_key_name=None, primary_key_columns=['id'])
 
     def test_success_view_with_definition(self):
-        RelationStructureDescription(
+        self.try_cons(kind='view', view_definition='select 1')
+
+    @pytest.mark.parametrize('kind,view_defn', [('table', 'select 1'), ('view', None)])
+    def test_fail_view_kind_vs_view_defn_mismatch(self, kind, view_defn):
+        with pytest.raises(
+            ValueError, match="Views require definitions, tables must not have view definition"
+        ):
+            self.try_cons(kind=kind, view_definition=view_defn)
+
+    def try_cons(self, **overlay_kwargs) -> RelationStructureDescription:
+        params = dict(
             schema_name='foo',
             relation_name='bar',
-            kind='view',
-            view_definition='select 1',
-            # rest is uninteresting for the test.
+            kind='table',
+            view_definition=None,
             primary_key_name=None,
             primary_key_columns=[],
             columns=[],
@@ -761,25 +734,9 @@ class TestRelationStructure:
             foreign_keys=[],
         )
 
-    @pytest.mark.parametrize('kind,view_defn', [('table', 'select 1'), ('view', None)])
-    def test_fail_view_kind_vs_view_defn_mismatch(self, kind, view_defn):
-        with pytest.raises(
-            ValueError, match="Views require definitions, tables must not have view definition"
-        ):
-            RelationStructureDescription(
-                schema_name='foo',
-                relation_name='bar',
-                kind=kind,
-                view_definition=view_defn,
-                # rest is uninteresting for the test.
-                primary_key_name=None,
-                primary_key_columns=[],
-                columns=[],
-                indexes=[],
-                unique_constraints=[],
-                check_constraints=[],
-                foreign_keys=[],
-            )
+        params.update(**overlay_kwargs)
+
+        RelationStructureDescription(**params)
 
 
 @pytest.mark.usefixtures("populated_sqlite_database")


### PR DESCRIPTION
New (undocumented) meta command \introspect to drive whole-database introspection and POSTing each discovered relation's structure up into Gate. Will ultimately be driven either magically at datasource creation time, or at worst through datasource '...' GUI element.

Was prototyped using a notebook calling into the existing Gate POST endpoint, over at [this notebook on integration](https://app.noteable-integration.us/f/94bc54fd-4cf8-47c0-a82c-8195753735ad/ThreadPoolExecutor.ipynb).

Open questions for future work:
  * Default concurrency level? Introspecting via the only API available in SQLA 1.4 requires many round-trips per relation, so is inherently slow. Can speed up over all using the ThreadPoolExecutor as we are here, but at what concurrency? Don't want to surpass the remote db's max connections. And / or as argument for the meta-command? Currently constanted as `MAX_INTROSPECTION_THREADS=10`. Also may need to ensure that the connection pool size backing the SQLA engine is at least this large, else threads > max connections in the pool are worthless.
  * Need new Gate API to either clear out all stored relations for this datasource id, and call it at the beginning (where have placeholder method `inform_gate_start()`, or maybe after having reported all we just observed and found, to then make a call indicating 'delete any in this datasource where created_at is earlier than X, where X was when we started'. Either way we need to clean out any 'old' garbage else when tables have been dropped in the real world database *after* they had been introspected and stored in gate.
  * New gate API allowing to POST a reasonably sized list of discovered relation structures, instead of one at a time.
  * Arguments for meta command for either schemas to exclude, or perhaps schemas to only visit?
  * Argument for meta command to just refresh single relation?


SQLA 2.0 will offer API for doing bulk table inspection, allowing this to be much faster (~6 or 7 queries total, independent of number of relations to discover), but will need 1) 2.0 to get released for real, and 2) each of our dialects needed here kernel-side to explicitly implement the new bulk apis. The default implementations in the base dialect will be lies, looping calling into the single-relation oriented API ;-(. Detecting which implementations are lies or not will probably be needed, then letting us chose which strategy to use (the existing threads-over-each-relation, or to actually use the bulk API and perhaps use separate threads for each substructure call, then interleave all results back in main thread to then report in these same per-table pydantic messages).


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [x] Have you validated this change locally?

