### PR TITLE
Handle unnamed primary keys encountered within \introspect.

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -760,7 +760,9 @@ class IntrospectAndStoreDatabaseCommand(MetaCommand):
         """
         primary_index_dict = inspector.get_pk_constraint(relation_name, schema_name)
 
-        pkey_name = primary_index_dict.get('name', '(unnamed primary key)')
+        # MySQL at least can have unnamed primary keys. The returned dict will have 'name' -> None.
+        # Sigh.
+        pkey_name = primary_index_dict.get('name') or '(unnamed primary key)'
 
         if primary_index_dict['constrained_columns']:
             return pkey_name, primary_index_dict['constrained_columns']

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -756,7 +756,7 @@ class TestFullIntrospection:
         """Ensure that no problems happen if primary keys are unnamed. We should inject '(unnamed primary key)' in
         as the name. ENG-5416."""
 
-        # Now introspect the whole DB after having made smell the PKs have no name,
+        # Introspect the whole DB after having made the PKs have no name via fixture patch_make_all_pks_unnamed().
         sql_magic.execute(rf'{COCKROACH_HANDLE} \introspect')
 
         out, err = capsys.readouterr()


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- \introspect doesn't properly handle unnamed primary keys (encountered today when testing Singlestore, a cloud hosted big data database that uses mysql client/server protocol). Will fail on some tables due to pydantic root validation proving that if there are pk columns being described, the pk must have a name.

- See https://noteableio.atlassian.net/browse/ENG-5416

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Fail to \introspect some tables.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- \introspection will succeed on tables / databases that support anonymous primary keys (ugh filthy things).


The safety error is fixed over in other branch, https://github.com/noteable-io/noteable-notebook-magics/pull/76, which will get merged before this branch.