### PR TITLE
Fix jinjasql+sqla vs object attribute dereferencing notation at jinjasql level.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,27 +43,24 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: poetry
 
-      - name: Install tox
-        run: pip install tox
-
       - name: Install CockroachDB
         uses: ./.github/actions/setup-cockroachdb
 
       # Run all of the tests
       - name: Flake8 - Style guide enforcement
-        run: tox -e flake8
+        run: poetry run flake8 noteable_magics/ tests/ --count --show-source --statistics --benchmark
         if: ${{ matrix.python-version == 3.9 }}
 
       - name: Black - Format check
-        run: tox -e black-check
+        run: poetry run black --diff noteable_magics/ tests/
         if: ${{ matrix.python-version == 3.9 }}
 
       - name: Isort - Import format check
-        run: tox -e isort-check
+        run: poetry run isort --diff --check noteable_magics/ tests/
         if: ${{ matrix.python-version == 3.9 }}
 
       - name: Safety - Python dependency vulnerability check
-        run: tox -e safety
+        run: poetry export --without-hashes -f requirements.txt | poetry run safety check --stdin -i 51457 -i 51668
         if: ${{ matrix.python-version == 3.9 }}
 
       - name: Set env

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,6 +43,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: poetry
 
+      - name: Install dependencies
+        shell: bash
+        run: poetry install
+
       - name: Install CockroachDB
         uses: ./.github/actions/setup-cockroachdb
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,5 +71,8 @@ jobs:
         id: vars
         run: PY_VER=${{ matrix.python-version }}; echo ::set-output name=tox_py::${PY_VER//.}
 
+      - name: Install tox for running tests with
+        run: pip install tox
+
       - name: Pytest - Unit tests
         run: tox -e py${{ steps.vars.outputs.tox_py }}

--- a/noteable_magics/sql/run.py
+++ b/noteable_magics/sql/run.py
@@ -112,7 +112,31 @@ def _commit(conn, config):
             pass  # not all engines can commit
 
 
-jinja_sql = JinjaSql(param_style='named')
+jinja_sql = JinjaSql(param_style='numeric')
+
+##
+# Why we use JinjaSql in numeric mode when feeding into SQLA text() expressions.
+#
+# We originally used 'named' format, which worked great in combination with SQLA text() parameter
+# syntax, up until trying to do object attribute dereferencing in jinja expressions
+# ("select id from foo where id = {{myobj.id}}"), at which time the resulting de-templated query
+# and bind params would be "select id from foo where id = :myobj.id" and {'myobj.id': 1}, which was
+# at least self-consistent until SQLA text() tries to convert that into the database driver's preferred parameter format
+# (say, pyformat) and would end up with *closing the parens too early* due to seeing the non-identifier
+# token '.': "select id from foo where id = %(myobj)s.id" with bind dict {'myobj.id': 1}, and croak
+# due to not finding exactly 'myobj' as key in the bind dict (had it made it past that, the query
+# still would have failed because the trailing '.id' would have been presented to the DB, which was never
+# the intent).
+#
+# So, to ensure that we pass only brain-dead-simple paramater expansion needs into the SQL text() expression,
+# we now drive jinja in numeric mode, so that it replaces templated variable expressions with just
+# a colon and a number ("select id from foo where id = :1"). It hands us back a list instead of a dict
+# as the bind parameters, but is easy enough to transform that list [12] into the dict of
+# string keys -> values ({'1': 12}) which SQLA's text() + conn.execute() expect for such a text() template.
+#
+# People don't much combine JinjaSQL on top of SQLA, in that they solve 'conditional composed SQL'
+# completely differently. We're special I guess?
+##
 
 
 def run(conn, sql, config, user_namespace, skip_boxing_scalar_result: bool):
@@ -123,9 +147,14 @@ def run(conn, sql, config, user_namespace, skip_boxing_scalar_result: bool):
             if first_word == "begin":
                 raise Exception("ipython_sql does not support transactions")
 
-            query, bind_params = jinja_sql.prepare_query(statement, user_namespace)
+            query, bind_list = jinja_sql.prepare_query(statement, user_namespace)
+
+            # Convert bind_list from positional list to dict per needs of a paramaterized text()
+            # construct.
+            bind_dict = {str(idx + 1): elem for (idx, elem) in enumerate(bind_list)}
+
             txt = sqlalchemy.sql.text(query)
-            result = conn.session.execute(txt, bind_params)
+            result = conn.session.execute(txt, bind_dict)
 
             _commit(conn=conn, config=config)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -295,6 +295,22 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "dparse"
+version = "0.6.2"
+description = "A parser for Python dependency files"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+packaging = "*"
+toml = "*"
+
+[package.extras]
+conda = ["pyyaml"]
+pipenv = ["pipenv"]
+
+[[package]]
 name = "duckdb"
 version = "0.6.1"
 description = "DuckDB embedded database"
@@ -1039,11 +1055,14 @@ asn1crypto = ">=1.5.1"
 
 [[package]]
 name = "packaging"
-version = "23.0"
+version = "21.3"
 description = "Core utilities for Python packages"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
@@ -1391,6 +1410,17 @@ docs = ["sphinx (!=5.2.0,!=5.2.0.post0)", "sphinx-rtd-theme"]
 test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 
 [[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "main"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
 name = "pytest"
 version = "7.2.1"
 description = "pytest: simple powerful testing with Python"
@@ -1638,6 +1668,29 @@ python-versions = ">=3.6,<4"
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.17.21"
+description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+category = "dev"
+optional = false
+python-versions = ">=3"
+
+[package.dependencies]
+"ruamel.yaml.clib" = {version = ">=0.2.6", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.11\""}
+
+[package.extras]
+docs = ["ryd"]
+jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.7"
+description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "s3transfer"
 version = "0.6.0"
 description = "An Amazon S3 Transfer Manager"
@@ -1650,6 +1703,26 @@ botocore = ">=1.12.36,<2.0a.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
+
+[[package]]
+name = "safety"
+version = "2.3.5"
+description = "Checks installed dependencies for known vulnerabilities and licenses."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Click = ">=8.0.2"
+dparse = ">=0.6.2"
+packaging = ">=21.0,<22.0"
+requests = "*"
+"ruamel.yaml" = ">=0.17.21"
+setuptools = ">=19.3"
+
+[package.extras]
+github = ["jinja2 (>=3.1.0)", "pygithub (>=1.43.3)"]
+gitlab = ["python-gitlab (>=1.3.0)"]
 
 [[package]]
 name = "scramp"
@@ -2083,7 +2156,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "8446e41ccd09748db6360fc98504fe5ba9f57ea92c48b48668cddda7f1672931"
+content-hash = "599037e635b517fc1c35da310d0ccc509b078057d55b8aeb7e094736011d4d41"
 
 [metadata.files]
 anyio = [
@@ -2346,6 +2419,10 @@ decorator = [
 distlib = [
     {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
     {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
+]
+dparse = [
+    {file = "dparse-0.6.2-py3-none-any.whl", hash = "sha256:8097076f1dd26c377f30d4745e6ec18fef42f3bf493933b842ac5bafad8c345f"},
+    {file = "dparse-0.6.2.tar.gz", hash = "sha256:d45255bda21f998bc7ddf2afd5e62505ba6134756ba2d42a84c56b0826614dfe"},
 ]
 duckdb = [
     {file = "duckdb-0.6.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e566514f9327f89264e98ac14ee7a84fbd9857328028258422c3e8375ee19d25"},
@@ -2947,8 +3024,8 @@ oscrypto = [
     {file = "oscrypto-1.3.0.tar.gz", hash = "sha256:6f5fef59cb5b3708321db7cca56aed8ad7e662853351e7991fcf60ec606d47a4"},
 ]
 packaging = [
-    {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
-    {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pandas = [
     {file = "pandas-1.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3749077d86e3a2f0ed51367f30bf5b82e131cc0f14260c4d3e499186fccc4406"},
@@ -3280,6 +3357,10 @@ pyopenssl = [
     {file = "pyOpenSSL-22.1.0-py3-none-any.whl", hash = "sha256:b28437c9773bb6c6958628cf9c3bebe585de661dba6f63df17111966363dd15e"},
     {file = "pyOpenSSL-22.1.0.tar.gz", hash = "sha256:7a83b7b272dd595222d672f5ce29aa030f1fb837630ef229f62e72e395ce8968"},
 ]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
 pytest = [
     {file = "pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5"},
     {file = "pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"},
@@ -3476,9 +3557,53 @@ rsa = [
     {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
     {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
 ]
+ruamel-yaml = [
+    {file = "ruamel.yaml-0.17.21-py3-none-any.whl", hash = "sha256:742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7"},
+    {file = "ruamel.yaml-0.17.21.tar.gz", hash = "sha256:8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af"},
+]
+ruamel-yaml-clib = [
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5859983f26d8cd7bb5c287ef452e8aacc86501487634573d260968f753e1d71"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:debc87a9516b237d0466a711b18b6ebeb17ba9f391eb7f91c649c5c4ec5006c7"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:df5828871e6648db72d1c19b4bd24819b80a755c4541d3409f0f7acd0f335c80"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:efa08d63ef03d079dcae1dfe334f6c8847ba8b645d08df286358b1f5293d24ab"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win32.whl", hash = "sha256:763d65baa3b952479c4e972669f679fe490eee058d5aa85da483ebae2009d231"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4b3a93bb9bc662fc1f99c5c3ea8e623d8b23ad22f861eb6fce9377ac07ad6072"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_12_0_arm64.whl", hash = "sha256:a234a20ae07e8469da311e182e70ef6b199d0fbeb6c6cc2901204dd87fb867e8"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:15910ef4f3e537eea7fe45f8a5d19997479940d9196f357152a09031c5be59f3"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:370445fd795706fd291ab00c9df38a0caed0f17a6fb46b0f607668ecb16ce763"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-win32.whl", hash = "sha256:ecdf1a604009bd35c674b9225a8fa609e0282d9b896c03dd441a91e5f53b534e"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-win_amd64.whl", hash = "sha256:f34019dced51047d6f70cb9383b2ae2853b7fc4dce65129a5acd49f4f9256646"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2aa261c29a5545adfef9296b7e33941f46aa5bbd21164228e833412af4c9c75f"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f01da5790e95815eb5a8a138508c01c758e5f5bc0ce4286c4f7028b8dd7ac3d0"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:40d030e2329ce5286d6b231b8726959ebbe0404c92f0a578c0e2482182e38282"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:c3ca1fbba4ae962521e5eb66d72998b51f0f4d0f608d3c0347a48e1af262efa7"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-win32.whl", hash = "sha256:7bdb4c06b063f6fd55e472e201317a3bb6cdeeee5d5a38512ea5c01e1acbdd93"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-win_amd64.whl", hash = "sha256:be2a7ad8fd8f7442b24323d24ba0b56c51219513cfa45b9ada3b87b76c374d4b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:91a789b4aa0097b78c93e3dc4b40040ba55bef518f84a40d4442f713b4094acb"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:99e77daab5d13a48a4054803d052ff40780278240a902b880dd37a51ba01a307"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:3243f48ecd450eddadc2d11b5feb08aca941b5cd98c9b1db14b2fd128be8c697"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:8831a2cedcd0f0927f788c5bdf6567d9dc9cc235646a434986a852af1cb54b4b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-win32.whl", hash = "sha256:3110a99e0f94a4a3470ff67fc20d3f96c25b13d24c6980ff841e82bafe827cac"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-win_amd64.whl", hash = "sha256:92460ce908546ab69770b2e576e4f99fbb4ce6ab4b245345a3869a0a0410488f"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5bc0667c1eb8f83a3752b71b9c4ba55ef7c7058ae57022dd9b29065186a113d9"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:4a4d8d417868d68b979076a9be6a38c676eca060785abaa6709c7b31593c35d1"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:bf9a6bc4a0221538b1a7de3ed7bca4c93c02346853f44e1cd764be0023cd3640"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:a7b301ff08055d73223058b5c46c55638917f04d21577c95e00e0c4d79201a6b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-win32.whl", hash = "sha256:d5e51e2901ec2366b79f16c2299a03e74ba4531ddcfacc1416639c557aef0ad8"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-win_amd64.whl", hash = "sha256:184faeaec61dbaa3cace407cffc5819f7b977e75360e8d5ca19461cd851a5fc5"},
+    {file = "ruamel.yaml.clib-0.2.7.tar.gz", hash = "sha256:1f08fd5a2bea9c4180db71678e850b995d2a5f4537be0e94557668cf0f5f9497"},
+]
 s3transfer = [
     {file = "s3transfer-0.6.0-py3-none-any.whl", hash = "sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd"},
     {file = "s3transfer-0.6.0.tar.gz", hash = "sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947"},
+]
+safety = [
+    {file = "safety-2.3.5-py3-none-any.whl", hash = "sha256:2227fcac1b22b53c1615af78872b48348661691450aa25d6704a5504dbd1f7e2"},
+    {file = "safety-2.3.5.tar.gz", hash = "sha256:a60c11f8952f412cbb165d70cb1f673a3b43a2ba9a93ce11f97e6a4de834aa3a"},
 ]
 scramp = [
     {file = "scramp-1.4.4-py3-none-any.whl", hash = "sha256:b142312df7c2977241d951318b7ee923d6b7a4f75ba0f05b621ece1ed616faa3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ setuptools = "^65.3.0"
 tox = "^3.23.1"
 managed-service-fixtures = "^0.1.5"
 requests-mock = "^1.10.0"
+safety = "^2.3.5"
 
 
 [build-system]

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -220,6 +220,25 @@ class TestJinjaTemplatesWithinSqlMagic:
         assert isinstance(results, int)
         assert results == expected_b_value
 
+    def test_query_dereferencing_object_attribute(self, sql_magic, ipython_shell):
+        class MyClass:
+            id: int
+
+            def __init__(self, id: int):
+                self.id = id
+
+        mc = MyClass(1)
+
+        ipython_shell.user_ns['mc'] = mc
+
+        ## jinjasql expansion including object attribute dereference!
+        results = sql_magic.execute(
+            COCKROACH_HANDLE + '\n#scalar select b from int_table where a = {{mc.id}}'
+        )
+
+        assert isinstance(results, int)
+        assert results == 2
+
     def test_insert_into(self, sql_magic, ipython_shell, capsys):
         """Create a one-off table, then test inserting into from python variables interpolated by jinja"""
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,57 +1,7 @@
 [tox]
 skipsdist = true
-envlist = py38, py39, flake8, black-check, isort-check, safety
+envlist = py38, py39
 
-# Linters
-[testenv:flake8]
-skip_install = true
-deps = flake8
-commands =
-    flake8 noteable_magics --count --show-source --statistics --benchmark
-    flake8 tests --count --show-source --statistics --benchmark
-
-# Black Apply
-[testenv:black]
-description = apply black linter with desired rules
-skip_install = true
-deps = black
-commands = black .
-
-# Black Check
-[testenv:black-check]
-description = apply black linter with desired rules
-skip_install = true
-deps = black
-commands = black --diff --check .
-
-# isort apply
-[testenv:isort]
-description = sort imports
-skip_install = true
-deps =
-      isort
-      colorama
-commands = isort planar_ally/ tests/
-
-# isort check
-[testenv:isort-check]
-description = sort imports
-skip_install = true
-deps =
-      isort
-      colorama
-commands = isort --diff --check planar_ally/ tests/
-
-[testenv:safety]
-deps = safety
-allowlist_externals =
-    poetry
-    sh
-# Vulnerability ID: 51457 is against a corner of 'py', referenced by tox. See
-# https://github.com/tox-dev/tox/issues/2524
-# 51668 is sqlalchemy wanting 2.0, but isn't not beta yet.
-commands =
-    sh -c "poetry export --without-hashes -f requirements.txt | safety check -i 51457 -i 51668 --stdin"
 
 [testenv]
 allowlist_externals = poetry
@@ -62,13 +12,8 @@ setenv =
     AWS_SECRET_ACCESS_KEY=foobar_secret
 passenv = *
 basepython =
-    black: python3.9
-    dist: python3.9
-    isort: python3.9
-    flake8: python3.9
     py39: python3.9
     py38: python3.8
-    safety: python3.9
 commands =
     poetry install -v
     poetry run pytest --timeout=460 --maxfail=4 --cov=noteable-notebook-magics {posargs}


### PR DESCRIPTION
jinjasql 'named' format worked great for simple derefencing when feeding into SQLA text() elements, but the two conspire to fail with more complex jinja expressions like object attribute accesses such as `{{foo.id}}`.

Switch to drive jinjasql in 'numeric' mode instead to ensure that the resulting placeholders remain simple for text() to parse, at the expense of needing to post-process the bind params now coming as a list, needing to be converted to a dict of str keys -> value. 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- See the big new comment in run.py.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

-  Jinja'd SQL cells like "select * from foo where id = {{slider.value}}" fail hard at SQLA level.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Such expressions should work.
