### PR TITLE
ENG-5517 special behavior for databricks.

### DIFF
--- a/noteable_magics/datasource_postprocessing.py
+++ b/noteable_magics/datasource_postprocessing.py
@@ -1,7 +1,7 @@
 import os
+import shutil
 from base64 import b64decode
 from pathlib import Path
-import shutil
 from tempfile import NamedTemporaryFile
 from typing import Any, Callable, Dict
 from urllib.parse import quote_plus, urlparse

--- a/noteable_magics/datasource_postprocessing.py
+++ b/noteable_magics/datasource_postprocessing.py
@@ -1,6 +1,7 @@
 import os
 from base64 import b64decode
 from pathlib import Path
+import shutil
 from tempfile import NamedTemporaryFile
 from typing import Any, Callable, Dict
 from urllib.parse import quote_plus, urlparse
@@ -260,3 +261,46 @@ def postprocess_awsathena(
 
     # 3. quote_plus s3_staging_dir
     create_engine_kwargs['s3_staging_dir'] = quote_plus(create_engine_kwargs['s3_staging_dir'])
+
+
+@register_postprocessor('databricks+connector')
+def postprocess_databricks(
+    datasource_id: str, dsn_dict: Dict[str, str], create_engine_kwargs: Dict[str, Any]
+) -> None:
+    """ENG-5517: If cluser_id is present, then make a $HOME/.databricks-connect file
+    with host, token, cluster_id, org_id, port. Also be sure to purge cluster_id, org_id,
+    port from create_engine_kwargs, in that these fields were added for only going into
+    this side file"""
+
+    cluster_id_key = 'cluster_id'
+    connect_file_opt_keys = [cluster_id_key, 'org_id', 'port']
+
+    # Collect data to json out into $HOME/.databricks-connect if we've got a cluster_id.
+    connect_args = create_engine_kwargs['connect_args']
+    if cluster_id_key in connect_args and shutil.which('databricks-connect'):
+        # host, token (actually, our password field) come from dsn_dict.
+        # (and what they want as 'host' is actually a https:// URL. Sigh.)
+        args = {
+            'host': f'https://{dsn_dict["host"]}/',
+            'token': dsn_dict['password'],
+        }
+        for key in connect_file_opt_keys:
+            if key in connect_args:
+                # be sure to int - > str the workspace/org id and port number as we xfer.
+                args[key] = str(connect_args[key])
+
+        connect_file_path = Path(os.environ['HOME']) / '.databricks-connect'
+
+        # rm -f any preexisting file.
+        if connect_file_path.exists():
+            connect_file_path.unlink()
+
+        # Now let databricks-connect external command (re)build it and do whatever
+        # else it does. See ENG-5517.
+        pipeline = f"echo y {args['host']} {args['token']} {args[cluster_id_key]} {args['org_id']} {args['port']} | databricks-connect configure"
+        os.system(pipeline)
+
+    # Always be sure to purge these only-for-.databricks-connect file args from create_engine_kwargs,
+    # even if not all were present.
+    for key in connect_file_opt_keys:
+        create_engine_kwargs.pop(key, '')

--- a/noteable_magics/datasources.py
+++ b/noteable_magics/datasources.py
@@ -75,7 +75,7 @@ def bootstrap_datasource(
 
     create_engine_kwargs = {'connect_args': connect_args}
 
-    # 'drivername' comes in via metadata, because reasons.
+    # 'drivername', and is really of form dialect(+drivername), comes in via metadata, because reasons.
     drivername = metadata['drivername']
     dsn_dict['drivername'] = drivername
 

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -1,9 +1,9 @@
 """ Tests over datasource bootstrapping """
 
 import json
+import os
 from pathlib import Path
 from typing import Callable, List
-import os
 from uuid import uuid4
 
 import pkg_resources


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Kick in major side effect behavior of driving script `databricks-connect configure` in a brittle, bruteforce way when bootstrapping databricks, cluster_id is present in connect_args, and `databricks-connect` is found in $PATH.
- See ENG-5517.
- This is intended to be a late addition to release/canada.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- No special databricks post-processing.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Will drive `databricks-connect configure` if we know our cluster-id.
