### PR TITLE
Test and fix the bugfixes.

### DIFF
--- a/noteable_magics/datasource_postprocessing.py
+++ b/noteable_magics/datasource_postprocessing.py
@@ -305,12 +305,14 @@ def postprocess_databricks(
         p = Popen(['databricks-connect', 'configure'], stdout=PIPE, stdin=PIPE, stderr=PIPE)
         try:
             _stdout, stderr = p.communicate(
+                # Indention fugly so as to not prefix each input with whitespace.
+                # And oh, be sure to have a newline betwen each input into the 'interactive' script.
                 input=f"""y
-    {args['host']}
-    {args['token']}
-    {args[cluster_id_key]}
-    {args['org_id']}
-    {args['port']}""".encode(),
+{args['host']}
+{args['token']}
+{args[cluster_id_key]}
+{args['org_id']}
+{args['port']}""".encode(),
                 timeout=DATABRICKS_CONNECT_SCRIPT_TIMEOUT,
             )
         except TimeoutExpired:

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -777,7 +777,7 @@ class TestDatabricks:
         # Expect to find things in it. See ENG-5517.
         # We can only test that we ran this mock script and the known result
         # of our mock script. What the real one does ... ?
-        contents = script_output.read().split()
+        contents = script_output.read().split('\n')
         assert len(contents) == 6
         assert contents[0] == 'y'
         assert contents[1] == f"https://{case_dict['hostname']}/"

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -733,7 +733,7 @@ class TestDatabricks:
         jsons_obj, specific_fields = jsons_for_extra_behavior
         create_engine_kwargs = {'connect_args': jsons_obj.connect_args_dict}
 
-        with pytest.raises(ValueError, match=f'databricks-connect took longer than'):
+        with pytest.raises(ValueError, match='databricks-connect took longer than'):
             datasource_postprocessing.postprocess_databricks(
                 datasource_id,
                 jsons_obj.dsn_dict,

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -3,7 +3,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable, List, Tuple
 from uuid import uuid4
 
 import pkg_resources
@@ -569,7 +569,7 @@ class TestDatabricks:
             os.environ['HOME'] = existing_home
 
     @pytest.fixture()
-    def databricks_connect_in_path(self, tmpdir: Path) -> tuple[Path, Path]:
+    def databricks_connect_in_path(self, tmpdir: Path) -> Tuple[Path, Path]:
         """Get a mock-ish executable 'databricks-connect' into an element in the path
         so that which('databricks-connect') will find something (see databricks post
         processor)
@@ -604,7 +604,7 @@ class TestDatabricks:
             os.environ['PATH'] = orig_path
 
     @pytest.fixture()
-    def jsons_for_extra_behavior(self) -> tuple[DatasourceJSONs, dict]:
+    def jsons_for_extra_behavior(self) -> Tuple[DatasourceJSONs, dict]:
         """Return a DatasourceJSONs describing databricks that will tickle postprocess_databricks()
         into doing its extra behavior. Also returns dict of some of the fields within that JSON."""
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- @MSeal added some fixes, but not tests exercising the newly handled conditions in https://github.com/noteable-io/noteable-notebook-magics/pull/85 . This adds tests covering those added codepaths, plus then fixes for issues found from the tests:
    - Must .decode() bytes coming up from Popen.stderr before adding to str when raising ValueError.
    - Properly handle TimeoutException if databricks-connect takes too long.
- And then also prove that the right dict is popped from (@MSeal fixed that issue in prior PR, this adds a test proving it).
- Tighten the screws on the test over observing how databricks-connect was driven (tail bit of `test_extra_behavior()`):
    - Prove script was fed _including newlines_ (original bug fixed in prior PR; just didn't tighten the exercising test that allowed lack of newlines to go unnoticed.)
    - Stop prepending script inputs with spaces imparted from the code indentation.

- History of the need for changes mine-able from, oh, https://noteables.slack.com/archives/C04HUA4GPGT/p1676437014275149?thread_ts=1675915901.222159&cid=C04HUA4GPGT downward.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Still some bugs in untested codepaths.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Fewer bugs.
- Now have 100% line and conditional coverage over fugly, duress-written `postprocess_databricks()`.
