### PR TITLE
Eng 5808 fix introspect databricks

### DIFF
--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -17,6 +17,7 @@ from pandas import DataFrame
 from sqlalchemy import inspect
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy.types import TypeEngine
 
 from noteable_magics.sql.connection import Connection
 from noteable_magics.sql.gate_messaging_types import (
@@ -424,13 +425,7 @@ class SingleRelationCommand(MetaCommand):
             names.append(col['name'])
 
             # Convert the possibly db-centric TypeEngine instance to a sqla-generic type string
-            try:
-                type_name = str(col['type'].as_generic()).lower()
-            except (NotImplementedError, AssertionError):
-                # ENG-5268: More esoteric types like UUID do not implement .as_generic()
-                # ENG-5808: Some Databricks types are not fully implemented and fail
-                # assertions within .as_generic()
-                type_name = str(col['type']).replace('()', '').lower()
+            type_name = determine_column_type_name(col['type'])
 
             types.append(type_name)
             nullables.append(col['nullable'])
@@ -807,11 +802,7 @@ class IntrospectAndStoreDatabaseCommand(MetaCommand):
         for col in column_dicts:
             comment = col.get('comment')  # Some dialects do not return.
 
-            try:
-                type_name = str(col['type'].as_generic()).lower()
-            except NotImplementedError:
-                # ENG-5268: More esoteric types like UUID do not implement .as_generic()
-                type_name = str(col['type']).replace('()', '').lower()
+            type_name = determine_column_type_name(col['type'])
 
             retlist.append(
                 ColumnModel(
@@ -1297,6 +1288,19 @@ def _raise_from_no_such_table(schema: str, relation_name: str):
     else:
         msg = f'Relation {relation_name} does not exist'
     raise MetaCommandException(msg)
+
+
+def determine_column_type_name(sqla_column_type_object: TypeEngine) -> str:
+    """Convert the possibly db-centric TypeEngine instance to a sqla-generic type string"""
+    try:
+        type_name = str(sqla_column_type_object.as_generic()).lower()
+    except (NotImplementedError, AssertionError):
+        # ENG-5268: More esoteric types like UUID do not implement .as_generic()
+        # ENG-5808: Some Databricks types are not fully implemented and fail
+        # assertions within .as_generic()
+        type_name = str(sqla_column_type_object).replace('()', '').lower()
+
+    return type_name
 
 
 def make_introspection_error_human_presentable(exception: Exception) -> str:

--- a/noteable_magics/sql/meta_commands.py
+++ b/noteable_magics/sql/meta_commands.py
@@ -426,8 +426,10 @@ class SingleRelationCommand(MetaCommand):
             # Convert the possibly db-centric TypeEngine instance to a sqla-generic type string
             try:
                 type_name = str(col['type'].as_generic()).lower()
-            except NotImplementedError:
+            except (NotImplementedError, AssertionError):
                 # ENG-5268: More esoteric types like UUID do not implement .as_generic()
+                # ENG-5808: Some Databricks types are not fully implemented and fail
+                # assertions within .as_generic()
                 type_name = str(col['type']).replace('()', '').lower()
 
             types.append(type_name)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Unit tests are present
- [x] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix introspecting databricks, at least for the three tables/views we have access to in our databricks account
- Unfortunately databricks SQLA dialect is telling us that the three relations are **both views and tables** (returned by inspector.get_table_names() AND ALSO ...get_view_names() .) Current logic in magics is to err on the side of view-ness in this case, but then the get_view_definiton() implementation of databricks driver is NotImplemented.
- But right now, FE doesn't do much anything different between an introspected table vs view except a different icon, so I'm not worried at this time.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Introspection fails.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Works. Local skaffold:
<img width="353" alt="Screenshot 2023-03-29 at 2 29 51 PM" src="https://user-images.githubusercontent.com/1128313/228638243-91f3c3cc-cf9c-4e69-9d9c-d14df9e4bb94.png">
<img width="328" alt="Screenshot 2023-03-29 at 2 48 19 PM" src="https://user-images.githubusercontent.com/1128313/228638255-94c34680-37e6-47af-9304-3ac98d0c74d2.png">

(Noel knows overly-long relation names need help here)