### PR TITLE
Refactor and make getting at SQL connections easy from python

### DIFF
--- a/noteable/__init__.py
+++ b/noteable/__init__.py
@@ -2,25 +2,22 @@ import pkg_resources
 
 __version__ = pkg_resources.get_distribution("noteable").version
 
-from .data_loader import LOCAL_DB_CONN_HANDLE, NoteableDataLoaderMagic, get_db_connection
+from .data_loader import NoteableDataLoaderMagic
 from .datasources import bootstrap_datasources
 from .logging import configure_logging
 from .ntbl import NTBLMagic
+from .sql.connection import bootstrap_duckdb
 from .sql.magic import SqlMagic
-from .sql.run import add_commit_blacklist_dialect
 
 
 def load_ipython_extension(ipython):
-    # Initialize any remote datasource connections
-    bootstrap_datasources()
-
-    # Always prevent sql-magic from trying to autocommit bigquery,
-    # for the legacy datasource support for Expel and whomever.
-    add_commit_blacklist_dialect('bigquery')
-
-    # Initialize the noteable local (duck_db) database connection
-    get_db_connection(LOCAL_DB_CONN_HANDLE)
-
     configure_logging(False, "INFO", "DEBUG")
 
+    # Initialize any remote datasource connections.
+    bootstrap_datasources()
+
+    # Initialize the noteable local (duck_db) database connection.
+    bootstrap_duckdb()
+
+    # Register all of our magics.
     ipython.register_magics(NoteableDataLoaderMagic, NTBLMagic, SqlMagic)

--- a/noteable/sql/__init__.py
+++ b/noteable/sql/__init__.py
@@ -1,1 +1,1 @@
-from .magic import *
+from .connection import get_sqla_connection, get_sqla_engine  # noqa

--- a/noteable/sql/magic.py
+++ b/noteable/sql/magic.py
@@ -149,7 +149,6 @@ class SqlMagic(Magics, Configurable):
             OperationalError,
             MetaCommandException,
         ) as e:
-
             # Normal syntax errors, missing table, etc. should come back as
             # ProgrammingError. And the rest indicate something fundamentally
             # broken at the DBAPI layer.
@@ -185,8 +184,8 @@ class SqlMagic(Magics, Configurable):
                 #
                 # "Restart Kernel" is too big of a hammer here.
                 #
-                conn._engine.dispose()
-                conn._session = None
+                conn.reset_connection_pool()
+
                 eprint(
                     "Encoutered the following unexpected exception while trying to run the statement."
                     " Closed the connection just to be safe. Re-run the cell to try again!\n\n"

--- a/noteable/sql/run.py
+++ b/noteable/sql/run.py
@@ -107,7 +107,7 @@ def _commit(conn, config):
 
     if _should_commit:
         try:
-            conn.session.execute("commit")
+            conn.sqla_connection.execute("commit")
         except sqlalchemy.exc.OperationalError:
             pass  # not all engines can commit
 
@@ -140,7 +140,6 @@ jinja_sql = JinjaSql(param_style='numeric')
 
 
 def run(conn, sql, config, user_namespace, skip_boxing_scalar_result: bool):
-
     if sql.strip():
         for statement in sqlparse.split(sql):
             first_word = sql.strip().split()[0].lower()
@@ -154,7 +153,7 @@ def run(conn, sql, config, user_namespace, skip_boxing_scalar_result: bool):
             bind_dict = {str(idx + 1): elem for (idx, elem) in enumerate(bind_list)}
 
             txt = sqlalchemy.sql.text(query)
-            result = conn.session.execute(txt, bind_dict)
+            result = conn.sqla_connection.execute(txt, bind_dict)
 
             _commit(conn=conn, config=config)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from noteable.planar_ally_client.types import (
     FileProgressUpdateContent,
     FileProgressUpdateMessage,
 )
-from noteable.sql.connection import Connection
+from noteable.sql.connection import Connection, bootstrap_duckdb
 from noteable.sql.magic import SqlMagic
 from noteable.sql.run import add_commit_blacklist_dialect
 
@@ -115,6 +115,14 @@ def with_empty_connections() -> None:
     yield
 
     Connection.connections = preexisting_connections
+
+
+@pytest.fixture
+def with_duckdb_bootstrapped(with_empty_connections) -> None:
+    # Normal magics bootstrapping will leave us with DuckDB connection populated.
+    bootstrap_duckdb()
+
+    yield
 
 
 @pytest.fixture

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -425,7 +425,6 @@ class TestSQLite:
     def test_failing_download(
         self, sql_magic, datasource_id, capsys, requests_mock, exc, expected_substring
     ):
-
         failing_url = 'mock://failed.download/'
 
         # Set up to simulate exception coming up while making requests.get() call to try to

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -86,7 +86,7 @@ class TestListSchemas:
 
         # Drop the view.
         connection = Connection.connections['@sqlite']
-        db = connection.session  # sic, a sqlalchemy.engine.base.Connection, not a Session. Sigh.
+        db = connection.sqla_connection
         db.execute('drop view str_int_view')
 
         sql_magic.execute(r'@sqlite \schemas+')


### PR DESCRIPTION
* Two new toplevel functions in package `noteable.sql`, aimed to let humans and AIs get at the SQLA objects backing SQL cells for fun and profit.
   * `get_sqla_engine(name_or_handle: str) -> Optional[Engine]`
   Given either the human-assigned name or the SQL cell handle for a datasource, return a SQLA Engine. Returns None if no such engine found.
   * `get_sqla_connection(name_or_handle: str) -> Optional[sqlalchemy.engine.base.Connection]` . Given either the human-assigned name or the SQL cell handle for a datasource, return a SQLA connection. Returns None if no such connection found.
   
   Implementations are in noteable.sql.connection module, imported into the parent package's __init__.

Then misc nonpublic cleanup:
* Move code around to be in better places, for example get stuff out of the data loader package that better belonged in sql.connection package.
* Rename the 'session' attribute of the sqlmagics-inherited `noteable.sql.connection.Connection` class to `sqla_connection`, because all along the property projected a SQLA Connection object, not a Session. Sigh.
* No longer have `noteable.sql.connection.Connection.get()` also insert upon not found. Move the bootstrapping of DuckDB connection to an explicit function that explicitly writes instead of inserting-by-get-side-effect.
* Tests, tests, tests.
