### PR TITLE
Convert wordy verify enum to expected clickhouse driver args

### DIFF
--- a/noteable/datasource_postprocessing.py
+++ b/noteable/datasource_postprocessing.py
@@ -340,10 +340,18 @@ def postprocess_clickhouse(
 
     # These are the enum options from the JSON schema for the dropdown titled "Secure Connection (HTTPS)"
     # Convert them to the values that the clickhouse driver expects.
-    verify = connect_args["verify"]
-    if verify == "Yes, use HTTPS":
+    secure_connection = connect_args.pop("secure_connection")
+    if secure_connection == "Yes, use HTTPS":
         connect_args.update({"protocol": "https", "verify": False})
-    elif verify == "Yes, use HTTPS and verify server certificate":
+    elif secure_connection == "Yes, use HTTPS and verify server certificate":
         connect_args.update({"protocol": "https", "verify": True})
-    elif verify == "No, use HTTP":
+    elif secure_connection == "No, use HTTP":
         connect_args.update({"protocol": "http", "verify": False})
+    else:
+        raise ValueError(
+            f"Unexpected value for secure_connection: {secure_connection}. "
+            "Expected one of: "
+            '"Yes, use HTTPS", '
+            '"Yes, use HTTPS and verify server certificate", '
+            '"No, use HTTP"'
+        )

--- a/noteable/datasource_postprocessing.py
+++ b/noteable/datasource_postprocessing.py
@@ -339,5 +339,12 @@ def postprocess_clickhouse(
 ) -> None:
     connect_args = create_engine_kwargs["connect_args"]
 
-    if connect_args["verify"] is True:
-        connect_args["verify"] = certifi.where()
+    # These are the enum options from the JSON schema for the dropdown titled "Secure Connection (HTTPS)"
+    # Convert them to the values that the clickhouse driver expects.
+    verify = connect_args["verify"]
+    if verify == "Yes, use HTTPS":
+        connect_args.update({"protocol": "https", "verify": False})
+    elif verify == "Yes, use HTTPS and verify server certificate":
+        connect_args.update({"protocol": "https", "verify": True})
+    elif verify == "No, use HTTP":
+        connect_args.update({"protocol": "http", "verify": False})

--- a/noteable/datasource_postprocessing.py
+++ b/noteable/datasource_postprocessing.py
@@ -7,6 +7,7 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Callable, Dict
 from urllib.parse import quote_plus, urlparse
 
+import certifi
 import structlog
 
 logger = structlog.get_logger(__name__)
@@ -338,10 +339,5 @@ def postprocess_clickhouse(
 ) -> None:
     connect_args = create_engine_kwargs["connect_args"]
 
-    # Pop the keys we want to use to build the query parameters in the connection string
-    # so that they don't get doubly passed down into the `noteable.sql.connection.Connection.set` call
-    # in `noteable.datasources.bootstrap_datasource()`.
-    dsn_dict["query"] = {
-        "protocol": connect_args.pop("protocol"),
-        "verify": str(connect_args.pop("verify")).lower(), # converts True/False to true/false
-    }
+    if connect_args["verify"] is True:
+        connect_args["verify"] = certifi.where()

--- a/noteable/datasource_postprocessing.py
+++ b/noteable/datasource_postprocessing.py
@@ -7,7 +7,6 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Callable, Dict
 from urllib.parse import quote_plus, urlparse
 
-import certifi
 import structlog
 
 logger = structlog.get_logger(__name__)

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -1078,44 +1078,24 @@ def test_postprocess_awsathena(input_dicts, expected_dicts):
 
 
 @pytest.mark.parametrize(
-    "input_dicts,expected_dsn_dict",
+    "input_create_engine_dict,expected_create_engine_dict",
     [
         (
-            (
-                # Input dsn dict
-                {'host': 'us-west-1', 'username': 'scott', 'password': 'tiger'},
-                # Input create engine dict
-                {'connect_args': {'protocol': 'https', 'verify': True}},
-            ),
-            # Expected DSN dict
-            {
-                'host': 'us-west-1',
-                'username': 'scott',
-                'password': 'tiger',
-                'query': {
-                    'protocol': 'https',
-                    'verify': 'true',
-                },
-            },
+            # Input create engine dict
+            {'connect_args': {'verify': 'Yes, use HTTPS'}},
+            # Expected connect_args dict
+            {'connect_args': {'protocol': 'https', 'verify': False}},
         ),
         (
-            (
-                {'host': 'us-west-1', 'username': 'scott', 'password': 'tiger'},
-                {'connect_args': {'protocol': 'https', 'verify': False}},
-            ),
-            {
-                'host': 'us-west-1',
-                'username': 'scott',
-                'password': 'tiger',
-                'query': {
-                    'protocol': 'https',
-                    'verify': 'false',
-                },
-            },
+            {'connect_args': {'verify': 'Yes, use HTTPS and verify server certificate'}},
+            {'connect_args': {'protocol': 'https', 'verify': True}},
+        ),
+        (
+            {'connect_args': {'verify': 'No, use HTTP'}},
+            {'connect_args': {'protocol': 'http', 'verify': False}},
         ),
     ],
 )
-def test_postprocess_clickhouse(input_dicts, expected_dsn_dict):
-    input_dsn_dict, input_create_engine_dict = input_dicts
-    datasource_postprocessing.postprocess_clickhouse(None, input_dsn_dict, input_create_engine_dict)
-    assert input_dsn_dict == expected_dsn_dict
+def test_postprocess_clickhouse(input_create_engine_dict, expected_create_engine_dict):
+    datasource_postprocessing.postprocess_clickhouse(None, None, input_create_engine_dict)
+    assert input_create_engine_dict == expected_create_engine_dict

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -1082,16 +1082,16 @@ def test_postprocess_awsathena(input_dicts, expected_dicts):
     [
         (
             # Input create engine dict
-            {'connect_args': {'verify': 'Yes, use HTTPS'}},
+            {'connect_args': {'secure_connection': 'Yes, use HTTPS'}},
             # Expected connect_args dict
             {'connect_args': {'protocol': 'https', 'verify': False}},
         ),
         (
-            {'connect_args': {'verify': 'Yes, use HTTPS and verify server certificate'}},
+            {'connect_args': {'secure_connection': 'Yes, use HTTPS and verify server certificate'}},
             {'connect_args': {'protocol': 'https', 'verify': True}},
         ),
         (
-            {'connect_args': {'verify': 'No, use HTTP'}},
+            {'connect_args': {'secure_connection': 'No, use HTTP'}},
             {'connect_args': {'protocol': 'http', 'verify': False}},
         ),
     ],
@@ -1099,3 +1099,10 @@ def test_postprocess_awsathena(input_dicts, expected_dicts):
 def test_postprocess_clickhouse(input_create_engine_dict, expected_create_engine_dict):
     datasource_postprocessing.postprocess_clickhouse(None, None, input_create_engine_dict)
     assert input_create_engine_dict == expected_create_engine_dict
+
+
+def test_postprocess_clickhouse_raises_on_bad_secure_connection():
+    with pytest.raises(ValueError):
+        datasource_postprocessing.postprocess_clickhouse(
+            None, None, {'connect_args': {'secure_connection': 'foobar'}}
+        )


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Create data connection JSON form accepts two fields: verify server certificate and protocol.
- Broken when verify is set to True.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Accept single new enum value `secure_connection` with options "Yes, use HTTPS", "Yes, use HTTPS and verify server certificate" and "No, use HTTP" and convert them accordingly to `verify` and `protocol` args for the driver.
