### PR TITLE
Fix SQLite and memory driver vs. postprocess_sqlite popping

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,6 +340,12 @@ def populated_cockroach_database(
     cleanup_any_extra_tables(connection)
 
 
+@pytest.fixture
+def tests_fixture_data() -> Path:
+    """Return Path pointing to tests/fixture_data/ dir"""
+    return Path(__file__).parent / 'fixture_data'
+
+
 @dataclass
 class DatasourceJSONs:
     meta_dict: Dict[str, Any]

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -330,12 +330,6 @@ class TestJinjaTemplatesWithinSqlMagic:
             assert results['b'].tolist() == expected_values
 
 
-@pytest.fixture
-def tests_fixture_data() -> Path:
-    """Return Path pointing to tests/fixture_data/ dir"""
-    return Path(__file__).parent / 'fixture_data'
-
-
 class TestSQLite:
     """Integration test cases of bootstrapping through to using SQLite datasource type datasource"""
 


### PR DESCRIPTION
max_downoad_seconds needs to be popped out of connect_args regardless of if a database name was given or not.

Issue reported by user at https://community.noteable.io/c/issues-and-bugs/cant-connect-to-sqlite-database

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?
