### PR TITLE
Separate connection registry functionality from connection modeling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Split registry vs. connection modeling roles: `noteable.sql.connection.Connection` class vs `noteable.sql.connection.ConnectionRegistry` class.
+
 ### Added
 - `%ntbl change-log-level --rtu-level DEBUG` will update relevant Sending, PA, and Origami libraries to render useful debug logs related to RTU processing in PA
 

--- a/noteable/__init__.py
+++ b/noteable/__init__.py
@@ -6,7 +6,6 @@ from .data_loader import NoteableDataLoaderMagic
 from .datasources import bootstrap_datasources
 from .logging import configure_logging
 from .ntbl import NTBLMagic
-from .sql.connection import bootstrap_duckdb
 from .sql.magic import SqlMagic
 
 
@@ -15,9 +14,6 @@ def load_ipython_extension(ipython):
 
     # Initialize any remote datasource connections.
     bootstrap_datasources()
-
-    # Initialize the noteable local (duck_db) database connection.
-    bootstrap_duckdb()
 
     # Register all of our magics.
     ipython.register_magics(NoteableDataLoaderMagic, NTBLMagic, SqlMagic)

--- a/noteable/data_loader.py
+++ b/noteable/data_loader.py
@@ -7,7 +7,8 @@ from IPython.utils.process import arg_split
 from traitlets import Bool, Int
 from traitlets.config import Configurable
 
-from noteable.sql.connection import LOCAL_DB_CONN_HANDLE, get_db_connection
+from noteable.datasources import LOCAL_DB_CONN_HANDLE
+from noteable.sql.connection import get_noteable_connection
 
 EXCEL_MIMETYPES = {
     "application/vnd.ms-excel",  # .xls
@@ -74,11 +75,7 @@ class NoteableDataLoaderMagic(Magics, Configurable):
         else:
             raise ValueError(f"File mimetype {mimetype} is not supported")
 
-        conn = get_db_connection(args.connection)
-        if not conn:
-            raise ValueError(
-                f"Could not find datasource identified by {args.connection!r}. Perhaps restart the kernel?"
-            )
+        conn = get_noteable_connection(args.connection)
 
         tmp_df.to_sql(
             tablename, conn.sqla_connection, if_exists="replace", index=args.include_index

--- a/noteable/datasources.py
+++ b/noteable/datasources.py
@@ -10,7 +10,7 @@ import structlog
 from sqlalchemy.engine import URL
 
 # ipython-sql thinks mighty highly of isself with this package name.
-import noteable.sql.connection
+from noteable.sql import connection
 from noteable.sql.run import add_commit_blacklist_dialect
 
 DEFAULT_SECRETS_DIR = Path('/vault/secrets')
@@ -63,9 +63,13 @@ def bootstrap_datasource_from_files(ds_meta_json_path: Path):
 
 
 def bootstrap_datasource(
-    datasource_id: str, meta_json: str, dsn_json: Optional[str], connect_args_json: Optional[str]
+    datasource_id: str,
+    meta_json: str,
+    dsn_json: Optional[str],
+    connect_args_json: Optional[str],
 ):
     """Bootstrap this single datasource from its three json definition JSON sections"""
+
     metadata = json.loads(meta_json)
 
     # Yes, bigquery connections may end up with nothing in dsn_json.
@@ -86,37 +90,43 @@ def bootstrap_datasource(
 
     # human-given name for the datasource is more likely than not present in the metadata
     # ('old' datasources in integration, staging, app.noteable.world may lack)
-    human_name = metadata.get('name')
+    human_name = metadata.get('name', 'Unnamed legacy connection')
 
-    # Do any per-drivername post-processing of and dsn_dict and create_engine_kwargs
-    # before we make use of any of their contents. Post-processors may end up rejecting this
-    # configuration, so catch and handle just like a failure when calling Connection.set().
-    if drivername in post_processor_by_drivername:
-        post_processor: Callable[[str, dict, dict], None] = post_processor_by_drivername[drivername]
-        try:
+    sql_cell_handle = f'@{datasource_id}'
+
+    connection_registry = connection.get_connection_registry()
+
+    try:
+        # Do any per-drivername post-processing of and dsn_dict and create_engine_kwargs
+        # before we make use of any of their contents. Post-processors may end up rejecting this
+        # configuration, so catch and handle just like a failure when calling Connection.set().
+        if drivername in post_processor_by_drivername:
+            post_processor: Callable[[str, dict, dict], None] = post_processor_by_drivername[
+                drivername
+            ]
             post_processor(datasource_id, dsn_dict, create_engine_kwargs)
-        except Exception as e:
-            logger.exception(
-                'Unable to bootstrap datasource',
-                datasource_id=datasource_id,
-                datasource_name=human_name,
-            )
 
-            # Remember the failure so can be shown if / when human tries to use the connection.
-            noteable.sql.connection.Connection.add_bootstrapping_failure(
-                datasource_id, human_name, str(e)
-            )
+        # Ensure the required driver packages are installed already, or, if allowed,
+        # install them on the fly.
+        ensure_requirements(
+            datasource_id,
+            metadata['required_python_modules'],
+            metadata['allow_datasource_dialect_autoinstall'],
+        )
 
-            # And bail early.
-            return
+    except Exception as e:
+        # Exception from either post_processor() or ensure_requirements().
+        logger.exception(
+            'Unable to bootstrap datasource',
+            datasource_id=datasource_id,
+            datasource_name=human_name,
+        )
 
-    # Ensure the required driver packages are installed already, or, if allowed,
-    # install them on the fly.
-    ensure_requirements(
-        datasource_id,
-        metadata['required_python_modules'],
-        metadata['allow_datasource_dialect_autoinstall'],
-    )
+        # Remember the failure so can be shown if / when human tries to use the connection.
+        connection_registry.add_bootstrapping_failure(sql_cell_handle, human_name, str(e))
+
+        # And bail early.
+        return
 
     # Prepare connection URL string.
     url_obj = URL.create(**dsn_dict)
@@ -131,32 +141,8 @@ def bootstrap_datasource(
         dialect = metadata['drivername'].split('+')[0]
         add_commit_blacklist_dialect(dialect)
 
-    # Teach ipython-sql about the connection!
-    try:
-        noteable.sql.connection.Connection.set(
-            connection_url,
-            name=f'@{datasource_id}',
-            human_name=human_name,
-            **create_engine_kwargs,
-        )
-    except Exception as e:
-        # Eat any exceptions coming up from trying to describe the connection down into SQLAlchemy.
-        # Bad data entered about the datasource that SQLA hates?
-        #
-        # If we don't eat this, then it will ultimately break us before we make the call to register
-        # the SQL Magics entirely, and will get errors like '%%sql magic unknown', which is far
-        # worse than attempts to use a broken datasource being met with it being unknown, but other
-        # datasources working fine.
-        logger.exception(
-            'Unable to bootstrap datasource',
-            datasource_id=datasource_id,
-            datasource_name=human_name,
-        )
-
-        # Remember the failure so can be shown if / when human tries to use the connection.
-        noteable.sql.connection.Connection.add_bootstrapping_failure(
-            datasource_id, human_name, str(e)
-        )
+    # Register the connection!
+    connection_registry.factory_and_register(sql_cell_handle, human_name, connection_url)
 
 
 ##

--- a/noteable/sql/connection.py
+++ b/noteable/sql/connection.py
@@ -1,9 +1,11 @@
-from typing import Dict, Optional, Union
+from typing import Dict, Optional
 
 import sqlalchemy
 import sqlalchemy.engine.base
 import structlog
 from sqlalchemy.engine import Engine
+
+__all__ = ('get_connection_registry', 'get_db_connection', 'get_sqla_connection', 'get_sqla_engine')
 
 logger = structlog.get_logger(__name__)
 
@@ -18,13 +20,16 @@ class UnknownConnectionError(Exception):
 
 
 class Connection:
-    current = None
-    connections: Dict[str, 'Connection'] = {}
-    bootstrapping_failures: Dict[str, str] = {}
+    sql_cell_handle: str
+    """Machine-accessible name/id, aka @35647345345345 ..."""
+    human_name: str
+    """Human assigned datasource name"""
 
-    def __init__(self, connect_str=None, name=None, human_name=None, **create_engine_kwargs):
+    def __init__(
+        self, sql_cell_handle: str, human_name: str, connection_url: str, **create_engine_kwargs
+    ):
         """
-        Construct + register a new 'connection', which in reality is a sqla Engine
+        Construct a new 'connection', which in reality is a sqla Engine
         plus some convienent metadata.
 
         Common args to go into the create_engine call (and therefore need to be
@@ -37,9 +42,7 @@ class Connection:
           * creator: Callable which itself returns the DBAPI connection. See
             https://docs-sqlalchemy.readthedocs.io/ko/latest/core/engines.html#custom-dbapi-connect-arguments
 
-        Sets the 'current' connection to the newly init'd one.
-
-        No session is immediately established (see the session property).
+        No SQLA-level connection is immediately established (see the `sqla_connection` property).
 
         'name' is what we call now the 'sql_cell_handle' -- starts with '@', followed by
         the hex of the datasource uuid (usually -- the legacy "local database" (was sqlite, now duckdb)
@@ -50,68 +53,45 @@ class Connection:
         due to having the same name used between user and space scopes, but so be it.
 
         """
-        if name and not name.startswith("@"):
-            raise ValueError("preassigned names must start with @")
+        if not sql_cell_handle.startswith("@"):
+            raise ValueError("sql_cell_handle values must start with '@'")
 
-        if "creator" in create_engine_kwargs and create_engine_kwargs["creator"] is None:
-            # As called from sql.magic in calling sql.connection.Connection.set,
-            # will always pass kwarg 'creator', but it will most likely be None.
-            # SQLA does not like it passed in as None (will still try to call it).
-            # So must remove the dict. Is cause for why legacy BigQuery connection
-            # fails.
-            del create_engine_kwargs["creator"]
+        if not human_name:
+            raise ValueError("Connections must have a human-assigned name")
 
-        try:
-            self._engine = sqlalchemy.create_engine(connect_str, **create_engine_kwargs)
-        except Exception:
-            # Most likely reason to end up here: cell being asked to use a datasource that wasn't bootstrapped
-            # as one of these Connections at kernel startup, and sql-magic ends up here, trying
-            # to create a new Connection on the fly. But if given only something like
-            # "@3453454567546" for the connect_str as from a SQL cell invocation, this obviously
-            # isn't enough to create a new SQLA engine.
-
-            logger.exception('Error creating new noteable.sql.Connection', connect_str=connect_str)
-
-            if connect_str.startswith('@'):
-                # Is indeed the above most likely reason. Cell ran something like "%sql @3244356456 select true",
-                # and magic.py's call to `conn = noteable_magics.sql.connection.Connection.set(...)`
-                # ended up here trying to create a new Connection and Engine because '@3244356456' didn't
-                # rendezvous with an already known bootstrapped datasource from vault via the startup-time bootstrapping
-                # noteable_magics.datasources.bootstrap_datasources() call. Most likely reason for that is because
-                # the user created the datasource _after_ when the kernel was launched and other checks and balances
-                # didn't prevent them from trying to gesture to use it in this kernel session.
-
-                # Maybe we've a known bootstrapping problem for it?
-                bootstrapping_error = self.get_bootstrapping_failure(connect_str)
-                if bootstrapping_error:
-                    error_msg = f'Please check data connection configuration, correct, and restart kernel:\n{bootstrapping_error}'
-                else:
-                    error_msg = "Cannot find data connection. If you recently created this connection, please restart the kernel."
-
-                raise UnknownConnectionError(error_msg)
-            else:
-                # Hmm. Maybe something desperately wrong at inside of a bootstrapped datasource? Just re-raise.
-                raise
-
-        self.dialect = self._engine.url.get_dialect()
-        self.metadata = sqlalchemy.MetaData(bind=self._engine)
-        self.name = name or self.assign_name(self._engine)
+        # Common bits to make it into base class when splittin this up into SQLA subclass and Random HTTP/Python Client API subclasses.
+        self.sql_cell_handle = sql_cell_handle
         self.human_name = human_name
-        self._sqla_connection = None
-        self.connections[name or repr(self.metadata.bind.url)] = self
 
-        Connection.current = self
+        # SLQA-centric fields hereon down, to be pushed into SQLA subclass in the future.
+        self._engine = sqlalchemy.create_engine(connection_url, **create_engine_kwargs)
+
+    def close(self):
+        """General-ish API method; SQLA-centric implementation"""
+        if self._sqla_connection:
+            self._sqla_connection.close()
+        self.reset_connection_pool()
+
+    ####
+    # SLQA-centric methods / properties here down
+    ####
 
     @property
     def engine(self) -> sqlalchemy.engine.base.Engine:
         return self._engine
 
     @property
+    def dialect(self):
+        return self.engine.url.get_dialect()
+
+    _sqla_connection: Optional[sqlalchemy.engine.base.Connection] = None
+
+    @property
     def sqla_connection(self) -> sqlalchemy.engine.base.Connection:
         """Lazily connect to the database. Return a SQLA Connection object, or die trying."""
 
         if not self._sqla_connection:
-            self._sqla_connection = self._engine.connect()
+            self._sqla_connection = self.engine.connect()
 
         return self._sqla_connection
 
@@ -122,113 +102,159 @@ class Connection:
         self._engine.dispose()
         self._sqla_connection = None
 
-    @classmethod
-    def set(
-        cls,
-        descriptor: Union[str, 'Connection'],
-        name: Optional[str] = None,
-        **create_engine_kwargs,
+
+class ConnectionRegistry:
+    """A registry of Connection instances"""
+
+    connections: Dict[str, Connection]
+    """My registry of connections. A single Connection will be multiply-registered, by its '@{sql_cell_handle}' as well as its 'human name' for convenience to humans."""
+
+    bootstrapping_failures: Dict[str, str]
+    """Deferred errors from bootstrapping time. The error will be correlated to both the sql_cell_handle and the human name."""
+
+    def __init__(self):
+        self.connections = {}
+        self.bootstrapping_failures = {}
+
+    def factory_and_register(
+        self, sql_cell_handle: str, human_name: str, connection_url: str, **kwargs
     ):
-        """Sets the current database connection. Will construct and cache new one on the fly if needed."""
+        """Factory a connection instance and register it.
 
-        if descriptor:
-            if isinstance(descriptor, Connection):
-                cls.current = descriptor
-            else:
-                existing = rough_dict_get(cls.connections, descriptor)
-                # http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#custom-dbapi-connect-arguments
-                cls.current = existing or Connection(
-                    descriptor,
-                    name,
-                    **create_engine_kwargs,
-                )
-        return cls.current
-
-    @classmethod
-    def assign_name(cls, engine):
-        name = "%s@%s" % (engine.url.username or "", engine.url.database)
-        return name
-
-    @classmethod
-    def connection_list(cls):
-        result = []
-        for key in sorted(cls.connections):
-            engine_url = cls.connections[key].metadata.bind.url  # type: sqlalchemy.engine.url.URL
-            if cls.connections[key] == cls.current:
-                template = " * {}"
-            else:
-                template = "   {}"
-            result.append(template.format(engine_url.__repr__()))
-        return "\n".join(result)
-
-    @classmethod
-    def find(cls, name: str) -> Optional['Connection']:
-        """Find a connection by SQL cell handle or by human assigned name"""
-        # TODO: Capt. Obvious says to double-register the instance by both of these keys
-        # to then be able to do lookups properly in this dict?
-        for c in cls.connections.values():
-            if c.name == name or c.human_name == name:
-                return c
-
-    @classmethod
-    def get_engine(cls, name: str) -> Optional[Engine]:
-        """Return the SQLAlchemy Engine given either the sql_cell_handle or
-        end-user assigned name for the connection.
+        If we encounter an exception at factory time, then remember it as a bootstrapping failure.
         """
-        maybe_conn = cls.find(name)
-        if maybe_conn:
-            return maybe_conn.engine
+        try:
+            conn = self.factory(sql_cell_handle, human_name, connection_url, **kwargs)
+        except Exception as e:
+            # Eat any exceptions coming up from trying to describe the connection down into SQLAlchemy.
+            # Bad data entered about the datasource that SQLA hates?
+            #
+            # If we don't eat this, then it will ultimately break us before we make the call to register
+            # the SQL Magics entirely, and will get errors like '%%sql magic unknown', which is far
+            # worse than attempts to use a broken datasource being met with it being unknown, but other
+            # datasources working fine.
+            logger.exception(
+                'Unable to bootstrap datasource',
+                sql_cell_handle=sql_cell_handle,
+                human_name=human_name,
+                exception=str(e),
+            )
 
-    @classmethod
-    def add_bootstrapping_failure(cls, name: str, human_name: Optional[str], error_message: str):
+            # Remember the failure so can be shown if / when human tries to use the connection.
+            self.add_bootstrapping_failure(
+                sql_cell_handle=sql_cell_handle, human_name=human_name, error_message=str(e)
+            )
+
+            return
+
+        # If still here, then all good.
+        self.register(conn)
+
+    def factory(self, sql_cell_handle: str, human_name: str, connection_url: str, **kwargs):
+        """Construct the appropriate Connection subclass.
+
+        Does not register the instance, only returns it.
+        """
+
+        # Simple for now, only knows how to make SQLA-ish Connection objs. Will generalize in later steps and figure out how
+        # to have the SQLA Connection subclass declare its preference for some, and other subclasses like Jira declare preference
+        # for others.
+        return Connection(
+            sql_cell_handle=sql_cell_handle,
+            human_name=human_name,
+            connection_url=connection_url,
+            **kwargs,
+        )
+
+    def register(self, conn: Connection):
+        """Register this connection into self under both its SQL cell handle it its human assigned name"""
+
+        if not isinstance(conn, Connection):
+            raise ValueError('connection must be a Connection instance')
+
+        if conn.sql_cell_handle in self.connections:
+            raise ValueError(
+                f'Datasource with handle {conn.sql_cell_handle} is already registered!'
+            )
+
+        self.connections[conn.sql_cell_handle] = conn
+        self.connections[conn.human_name] = conn
+
+        self.bootstrapping_failures.pop(conn.sql_cell_handle, None)
+        self.bootstrapping_failures.pop(conn.human_name, None)
+
+    def add_bootstrapping_failure(self, sql_cell_handle: str, human_name: str, error_message: str):
         """Remember (short) reason why we could not bootstrap a connection by this name,
         so that we can tell the user about it if / when they try to use the connection
         in a SQL cell.
         """
 
-        cls.bootstrapping_failures[name] = error_message
-        if human_name:
-            cls.bootstrapping_failures[human_name] = error_message
+        if sql_cell_handle in self.connections:
+            raise ValueError(
+                'Strange: this connection is already defined, but now reporting bootstrapping failure? Perhaps close_and_pop() first?'
+            )
 
-    @classmethod
-    def get_bootstrapping_failure(cls, handle_or_id: str) -> Optional[str]:
+        self.bootstrapping_failures[sql_cell_handle] = error_message
+        self.bootstrapping_failures[human_name] = error_message
+
+    def get(self, handle_or_human_name: str) -> Optional[Connection]:
+        """Find a connection by SQL cell handle or by human assigned name. If not present and expected,
+        then perhaps call get_bootstrapping_failure() to learn of any deferred construction issues.
+        """
+
+        if conn := self.connections.get(handle_or_human_name):
+            return conn
+
+        # Perhaps had bootstrapping error?
+        if bootstrapping_error := self.get_bootstrapping_failure(handle_or_human_name):
+            # Could use a better exception type here.
+            raise UnknownConnectionError(
+                f'Please check data connection configuration, correct, and restart kernel:\n{bootstrapping_error}'
+            )
+
+        # Otherwise is just plain unknown.
+        raise UnknownConnectionError(
+            'Cannot find data connection. If you recently created this connection, please restart the kernel.'
+        )
+
+    def get_bootstrapping_failure(self, handle_or_name: str) -> Optional[str]:
         """Return failure-to-bootstrap reason (if any) related to this
         datasource by either its sql handle / id ("@3464564") or its human
         name ("My PostgreSQL")
         """
-        return rough_dict_get(cls.bootstrapping_failures, handle_or_id)
+        return self.bootstrapping_failures.get(handle_or_name)
 
-    def _close(cls, descriptor):
-        if isinstance(descriptor, Connection):
-            conn = descriptor
-        else:
-            conn = cls.connections.get(descriptor) or cls.connections.get(descriptor.lower())
-        if not conn:
-            raise Exception(
-                "Could not close connection because it was not found amongst these: %s"
-                % str(cls.connections.keys())
-            )
-        cls.connections.pop(conn.name, None)
-        cls.connections.pop(str(conn.metadata.bind.url), None)
-        conn.sqla_connection.close()
+    def close_and_pop(self, handle_or_name: str):
+        """If this handle_or_name is in self, then close it and forget about it."""
 
-    def close(self):
-        self.__class__._close(self)
+        conn = self.connections.get(handle_or_name)
+        if conn:
+            try:
+                conn.close()
+            finally:
+                self.connections.pop(conn.sql_cell_handle, None)
+                self.connections.pop(conn.human_name, None)
+
+        self.bootstrapping_failures.pop(handle_or_name, None)
+
+    def __len__(self):
+        # Each Connection is double-registered under both sql_cell_handle and human name, so div by two.
+        return len(self.connections) // 2
+
+    def __contains__(self, key: str):
+        return key in self.connections
 
 
-def rough_dict_get(dct, sought, default=None):
-    """
-    Like dct.get(sought), but any key containing sought will do.
+_registry_singleton: Optional[ConnectionRegistry] = None
 
-    If there is a `@` in sought, seek each piece separately.
-    This lets `me@server` match `me:***@myserver/db`
-    """
 
-    sought = sought.split("@")
-    for key, val in dct.items():
-        if not any(s.lower() not in key.lower() for s in sought):
-            return val
-    return default
+def get_connection_registry() -> ConnectionRegistry:
+    global _registry_singleton
+
+    if _registry_singleton is None:
+        _registry_singleton = ConnectionRegistry()
+
+    return _registry_singleton
 
 
 def get_db_connection(name_or_handle: str) -> Optional[Connection]:
@@ -238,28 +264,28 @@ def get_db_connection(name_or_handle: str) -> Optional[Connection]:
     Will return None if the given handle isn't present in
     the connections dict already (created after this kernel was launched?)
     """
-    return Connection.find(name_or_handle)
+    return get_connection_registry().get(name_or_handle)
 
 
 def get_sqla_connection(name_or_handle: str) -> Optional[sqlalchemy.engine.base.Connection]:
     """Return a SQLAlchemy connection given a name or handle
-    Returns None if cannot find by this string.
+    Returns None if cannot find by this string, or the given Connection doesn't support SQLA.
     """
-    nconn = get_db_connection(name_or_handle)
-    if nconn:
-        return nconn.sqla_connection
+    conn = get_connection_registry().get(name_or_handle)
+    if conn and hasattr(conn, 'sqla_connection'):
+        return conn.sqla_connection
 
 
 def get_sqla_engine(name_or_handle: str) -> Optional[Engine]:
     """Return a SQLAlchemy Engine given a name or handle.
     Returns None if cannot find by this string.
     """
-    return Connection.get_engine(name_or_handle)
+    return get_connection_registry().get(name_or_handle).engine
 
 
 def bootstrap_duckdb():
-    Connection.set(
-        DUCKDB_LOCATION,
+    get_connection_registry().factory_and_register(
+        sql_cell_handle=LOCAL_DB_CONN_HANDLE,
         human_name=LOCAL_DB_CONN_NAME,
-        name=LOCAL_DB_CONN_HANDLE,
+        connection_url=DUCKDB_LOCATION,
     )

--- a/noteable/sql/connection.py
+++ b/noteable/sql/connection.py
@@ -210,6 +210,8 @@ class ConnectionRegistry:
     def get(self, handle_or_human_name: str) -> Optional[Connection]:
         """Find a connection by SQL cell handle or by human assigned name. If not present and expected,
         then perhaps call get_bootstrapping_failure() to learn of any deferred construction issues.
+
+        Raises UnknownConnectionError if there is no Connection registered by this name.
         """
 
         if conn := self.connections.get(handle_or_human_name):

--- a/noteable/sql/magic.py
+++ b/noteable/sql/magic.py
@@ -89,7 +89,7 @@ class SqlMagic(Magics, Configurable):
 
         parsed = noteable.sql.parse.parse(command_text, self)
 
-        datasource_sql_cell_hande = parsed["connection"]
+        datasource_sql_cell_handle = parsed["connection"]
 
         # Get ahold of the connection to use. Original sql-magic lifecycle was to create connections
         # on the fly within cells via magic invocations. Said connection would then become the
@@ -100,7 +100,7 @@ class SqlMagic(Magics, Configurable):
         # expect to use the get portion. If an unknown datasource handle (say, handle of a datasource created _after_
         # kernel launch / our bootstrapping) gets passed into here, an exception will be raised.
         try:
-            conn = get_connection_registry().get(datasource_sql_cell_hande)
+            conn = get_connection_registry().get(datasource_sql_cell_handle)
         except noteable.sql.connection.UnknownConnectionError as e:
             # Cell referenced a datasource we don't know about. Exception will have a short + sweet message.
             eprint(str(e))

--- a/noteable/sql/magic.py
+++ b/noteable/sql/magic.py
@@ -10,9 +10,9 @@ from sqlalchemy.exc import (
     ProgrammingError,
 )
 
-import noteable.sql.connection
 import noteable.sql.parse
 import noteable.sql.run
+from noteable.sql.connection import get_connection_registry
 from noteable.sql.meta_commands import MetaCommandException, run_meta_command
 
 try:
@@ -89,7 +89,7 @@ class SqlMagic(Magics, Configurable):
 
         parsed = noteable.sql.parse.parse(command_text, self)
 
-        connect_str = parsed["connection"]
+        datasource_sql_cell_hande = parsed["connection"]
 
         # Get ahold of the connection to use. Original sql-magic lifecycle was to create connections
         # on the fly within cells via magic invocations. Said connection would then become the
@@ -100,9 +100,7 @@ class SqlMagic(Magics, Configurable):
         # expect to use the get portion. If an unknown datasource handle (say, handle of a datasource created _after_
         # kernel launch / our bootstrapping) gets passed into here, an exception will be raised.
         try:
-            conn = noteable.sql.connection.Connection.set(
-                connect_str,
-            )
+            conn = get_connection_registry().get(datasource_sql_cell_hande)
         except noteable.sql.connection.UnknownConnectionError as e:
             # Cell referenced a datasource we don't know about. Exception will have a short + sweet message.
             eprint(str(e))

--- a/noteable/sql/meta_commands.py
+++ b/noteable/sql/meta_commands.py
@@ -848,7 +848,7 @@ class IntrospectAndStoreDatabaseCommand(MetaCommand):
         Will fail with ValueError if attempted against a legacy datasource handle like '@noteable', so
         please don't try to introspect within SQL cells from those.
         """
-        handle = self.conn.name
+        handle = self.conn.sql_cell_handle
         return UUID(handle[1:])
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from managed_service_fixtures import CockroachDetails
 from sqlalchemy import inspect
 from sqlalchemy.orm import Session
 
+from noteable.datasources import bootstrap_duckdb
 from noteable.logging import RawLogCapture, configure_logging
 from noteable.planar_ally_client.api import PlanarAllyAPI
 from noteable.planar_ally_client.types import (
@@ -19,7 +20,7 @@ from noteable.planar_ally_client.types import (
     FileProgressUpdateMessage,
 )
 from noteable.sql import connection
-from noteable.sql.connection import Connection, bootstrap_duckdb, get_connection_registry
+from noteable.sql.connection import Connection, get_connection_registry
 from noteable.sql.magic import SqlMagic
 from noteable.sql.run import add_commit_blacklist_dialect
 
@@ -121,7 +122,7 @@ def with_empty_connections() -> None:
 @pytest.fixture
 def with_duckdb_bootstrapped(with_empty_connections) -> None:
     # Normal magics bootstrapping will leave us with DuckDB connection populated.
-    bootstrap_duckdb()
+    bootstrap_duckdb(get_connection_registry())
 
     yield
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,6 +1,14 @@
 import pytest
+import sqlalchemy.engine.base
 
-from noteable.sql.connection import Connection, get_connection_registry
+from noteable.sql.connection import (
+    Connection,
+    UnknownConnectionError,
+    get_connection_registry,
+    get_noteable_connection,
+    get_sqla_connection,
+    get_sqla_engine,
+)
 
 
 class TestConnection:
@@ -39,3 +47,57 @@ class TestConnectionRegistry:
             registry.add_bootstrapping_failure(
                 handle, human_name, 'Whacktastical late error reporting, Batman!'
             )
+
+    def test_can_find_by_either_sql_cell_handle_or_human_name(self, sqlite_database_connection):
+        registry = get_connection_registry()
+
+        handle, human_name = sqlite_database_connection
+
+        assert registry.get(handle) == registry.get(human_name) and isinstance(
+            registry.get(handle), Connection
+        )
+
+
+class TestGetNoteableConnection:
+    def test_can_get_by_either_sql_cell_handle_or_human_name(self, sqlite_database_connection):
+        handle, human_name = sqlite_database_connection
+
+        assert get_noteable_connection(handle) == get_noteable_connection(
+            human_name
+        ) and isinstance(get_noteable_connection(handle), Connection)
+
+    def test_raises_if_not_found(self):
+        with pytest.raises(UnknownConnectionError):
+            get_noteable_connection('unknown connection')
+
+    # will test raising on non-SLQA supported connection when first one is implemented.
+
+
+class TestGetSqlaConnection:
+    def test_can_get_by_either_sql_cell_handle_or_human_name(self, sqlite_database_connection):
+        handle, human_name = sqlite_database_connection
+
+        assert get_sqla_connection(handle) == get_sqla_connection(human_name) and isinstance(
+            get_sqla_connection(handle), sqlalchemy.engine.base.Connection
+        )
+
+    def test_raises_if_not_found(self):
+        with pytest.raises(UnknownConnectionError):
+            get_sqla_connection('unknown connection')
+
+    # will test raising on non-SLQA supported connection when first one is implemented.
+
+
+class TestGetSqlaEngine:
+    def test_can_get_by_either_sql_cell_handle_or_human_name(self, sqlite_database_connection):
+        handle, human_name = sqlite_database_connection
+
+        assert get_sqla_engine(handle) == get_sqla_engine(human_name) and isinstance(
+            get_sqla_engine(handle), sqlalchemy.engine.Engine
+        )
+
+    def test_raises_if_not_found(self):
+        with pytest.raises(UnknownConnectionError):
+            get_sqla_engine('unknown connection')
+
+    # will test raising on non-SLQA supported connection when first one is implemented.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,41 @@
+import pytest
+
+from noteable.sql.connection import Connection, get_connection_registry
+
+
+class TestConnection:
+    def test_sql_cell_handles_must_start_with_at(self):
+        with pytest.raises(ValueError, match="sql_cell_handle values must start with '@'"):
+            Connection('no_leading_at', 'sdf', 'sqlite:///:memory:')
+
+    def test_must_have_human_name(self):
+        with pytest.raises(ValueError, match="Connections must have a human-assigned name"):
+            Connection('@foo', '', 'sqlite:///:memory:')
+
+
+class TestConnectionRegistry:
+    def test_hates_null_connection(self):
+        registry = get_connection_registry()
+        with pytest.raises(ValueError, match='must be a Connection instance'):
+            registry.register(None)
+
+    def test_hates_double_registration(self, sqlite_database_connection):
+        # The sqlite_database_connection fixture will have already registered it.
+        registry = get_connection_registry()
+
+        handle, human_name = sqlite_database_connection
+
+        with pytest.raises(ValueError, match='is already registered'):
+            registry.register(Connection(handle, human_name, 'sqlite:///:memory:'))
+
+    def tests_hates_double_reported_bootstrapping_failures(self, sqlite_database_connection):
+        registry = get_connection_registry()
+
+        handle, human_name = sqlite_database_connection
+
+        with pytest.raises(
+            ValueError, match='s already defined, but now reporting bootstrapping failure'
+        ):
+            registry.add_bootstrapping_failure(
+                handle, human_name, 'Whacktastical late error reporting, Batman!'
+            )

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -427,13 +427,17 @@ class TestBootstrapDatasource:
 
         case_data = SampleData.get_sample(sample_name)
 
+        registry = get_connection_registry()
+
         datasources.bootstrap_datasource(
-            datasource_id, case_data.meta_json, case_data.dsn_json, case_data.connect_args_json
+            registry,
+            datasource_id,
+            case_data.meta_json,
+            case_data.dsn_json,
+            case_data.connect_args_json,
         )
 
         # Check over the created 'Connection' instance.
-
-        registry = get_connection_registry()
 
         # Alas, in Connection parlance, 'name' == 'sql_cell_handle', and 'human_name'
         # is the human-assigned name for the datasource. Sigh.
@@ -493,7 +497,11 @@ class TestBootstrapDatasource:
         # Trying to bootstrap this one will fail somewhat silently -- will log exception, but
         # ultimately not having added new entry into Connection.connections.
         datasources.bootstrap_datasource(
-            datasource_id, case_data.meta_json, case_data.dsn_json, case_data.connect_args_json
+            registry,
+            datasource_id,
+            case_data.meta_json,
+            case_data.dsn_json,
+            case_data.connect_args_json,
         )
 
         assert len(registry) == initial_len
@@ -532,7 +540,11 @@ class TestBootstrapDatasource:
         registry = get_connection_registry()
 
         datasources.bootstrap_datasource(
-            datasource_id, case_data.meta_json, case_data.dsn_json, case_data.connect_args_json
+            registry,
+            datasource_id,
+            case_data.meta_json,
+            case_data.dsn_json,
+            case_data.connect_args_json,
         )
 
         assert len(registry) == 1
@@ -568,12 +580,17 @@ class TestBootstrapDatasource:
         # die a very different death, complaining about cannot find any credentials anywhere
         # since not passed in and the google magic env var isn't set.
 
+        registry = get_connection_registry()
+
         datasources.bootstrap_datasource(
-            datasource_id, case_data.meta_json, case_data.dsn_json, case_data.connect_args_json
+            registry,
+            datasource_id,
+            case_data.meta_json,
+            case_data.dsn_json,
+            case_data.connect_args_json,
         )
 
         # No successful side effect.
-        registry = get_connection_registry()
 
         assert len(registry) == 0
 
@@ -596,7 +613,11 @@ class TestBootstrapDatasource:
         pg_details = SampleData.get_sample('simple-postgres')
 
         datasources.bootstrap_datasource(
-            datasource_id, pg_details.meta_json, pg_details.dsn_json, pg_details.connect_args_json
+            get_connection_registry(),
+            datasource_id,
+            pg_details.meta_json,
+            pg_details.dsn_json,
+            pg_details.connect_args_json,
         )
 
         # At least look for signs of the side-effect. Can't test it actually does the
@@ -821,11 +842,16 @@ class TestDatabricks:
 
         assert 'cluster_id' in case_data.connect_args_dict
 
+        registry = get_connection_registry()
+
         datasources.bootstrap_datasource(
-            datasource_id, case_data.meta_json, case_data.dsn_json, case_data.connect_args_json
+            registry,
+            datasource_id,
+            case_data.meta_json,
+            case_data.dsn_json,
+            case_data.connect_args_json,
         )
 
-        registry = get_connection_registry()
         assert len(registry) == 1
 
         # Preexisting file should have been unlinked. The real databricks-connect
@@ -864,12 +890,17 @@ class TestDatabricks:
 
         case_data, case_dict = jsons_for_extra_behavior
 
+        registry = get_connection_registry()
+
         # Should not fail, but won't have done any extra behavior.
         datasources.bootstrap_datasource(
-            datasource_id, case_data.meta_json, case_data.dsn_json, case_data.connect_args_json
+            registry,
+            datasource_id,
+            case_data.meta_json,
+            case_data.dsn_json,
+            case_data.connect_args_json,
         )
 
-        registry = get_connection_registry()
         assert len(registry) == 1
 
         # Left unchanged
@@ -895,11 +926,16 @@ class TestDatabricks:
         # Should not have triggered extra behavior -- cluster_id wasn't present (but
         # we do have a databricks-connect script in the PATH).
 
+        registry = get_connection_registry()
+
         datasources.bootstrap_datasource(
-            datasource_id, case_data.meta_json, case_data.dsn_json, case_data.connect_args_json
+            registry,
+            datasource_id,
+            case_data.meta_json,
+            case_data.dsn_json,
+            case_data.connect_args_json,
         )
 
-        registry = get_connection_registry()
         assert len(registry) == 1
 
         # But won't have breathed on dotconnect file.
@@ -1000,7 +1036,11 @@ class TestSQLite:
         jsons = SampleData.get_sample('memory-sqlite-also-with-max_download_seconds')
 
         datasources.bootstrap_datasource(
-            datasource_id, jsons.meta_json, jsons.dsn_json, jsons.connect_args_json
+            get_connection_registry(),
+            datasource_id,
+            jsons.meta_json,
+            jsons.dsn_json,
+            jsons.connect_args_json,
         )
 
         engine = get_sqla_engine(jsons.meta_dict['name'])
@@ -1029,7 +1069,11 @@ class TestSQLite:
         )
 
         datasources.bootstrap_datasource(
-            datasource_id, bad_sqlite.meta_json, bad_sqlite.dsn_json, bad_sqlite.connect_args_json
+            get_connection_registry(),
+            datasource_id,
+            bad_sqlite.meta_json,
+            bad_sqlite.dsn_json,
+            bad_sqlite.connect_args_json,
         )
 
         registry = get_connection_registry()

--- a/tests/test_sql_init_package.py
+++ b/tests/test_sql_init_package.py
@@ -1,0 +1,21 @@
+import pytest
+import sqlalchemy.engine
+import sqlalchemy.engine.base
+
+# These functions are consciously exposed for use within Notebooks.
+from noteable.sql import get_sqla_connection, get_sqla_engine
+
+
+class TestToplevelExposedConvenienceGetters:
+    @pytest.mark.parametrize(
+        'convenence_function,expected_class',
+        [
+            (get_sqla_connection, sqlalchemy.engine.base.Connection),
+            (get_sqla_engine, sqlalchemy.engine.Engine),
+        ],
+    )
+    def test_get_sqla_connection(
+        self, convenence_function, expected_class, sqlite_database_connection
+    ):
+        for name in sqlite_database_connection:  # both the sql cell handle and the human name ...
+            assert isinstance(convenence_function(name), expected_class)

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -131,20 +131,14 @@ class TestSqlMagic:
         # Should NOT have also assigned the exception to global 'my_df' in the ipython shell.
         assert 'my_df' not in ipython_shell.user_ns
 
-    def test_unknown_datasource_handle_produces_expected_exception(self, sql_magic, capsys):
-        from noteable.sql.connection import Connection, UnknownConnectionError
-
-        initial_connection_count = len(Connection.connections)
+    def test_unknown_datasource_handle_produces_expected_exception(
+        self, sql_magic, capsys, session_durable_registry
+    ):
+        initial_connection_count = len(session_durable_registry)
         # sql magic invocation of an unknown connection will end up calling .set() with
         # that unknown connection's handle. Should raise. (This is unit-test-y)
         # Verbiage from ENG-4264.
         expected_message = "Cannot find data connection. If you recently created this connection, please restart the kernel."
-
-        with pytest.raises(
-            UnknownConnectionError,
-            match=expected_message,
-        ):
-            Connection.set('@45645675', False)
 
         # ... and when run through the magic, the magic will return None, but print the message out as
         # the cell's output. (This is more integration test-y, or at least higher-level unit-test-y.)
@@ -153,7 +147,7 @@ class TestSqlMagic:
         assert captured.err == f"{expected_message}\n"
 
         # Finally, the total number of known connections should have remained the same.
-        assert len(Connection.connections) == initial_connection_count
+        assert len(session_durable_registry) == initial_connection_count
 
 
 @pytest.mark.usefixtures("populated_cockroach_database", "populated_sqlite_database")

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -12,6 +12,7 @@ from pandas.testing import assert_frame_equal
 from sqlalchemy.exc import OperationalError
 
 from noteable import datasources
+from noteable.sql.connection import get_connection_registry
 from noteable.sql.run import ResultSet
 from tests.conftest import COCKROACH_HANDLE, DatasourceJSONs
 
@@ -477,7 +478,11 @@ class TestSQLite:
             jsons.connect_args_dict = {'max_download_seconds': max_download_seconds}
 
         datasources.bootstrap_datasource(
-            datasource_id, jsons.meta_json, jsons.dsn_json, jsons.connect_args_json
+            get_connection_registry(),
+            datasource_id,
+            jsons.meta_json,
+            jsons.dsn_json,
+            jsons.connect_args_json,
         )
 
 
@@ -532,7 +537,11 @@ class TestAmazonAthena:
         # Should get postprocessed properly by postprocess_awsathena(), otherwise test
         # will definitely fail.
         datasources.bootstrap_datasource(
-            datasource_id, jsons.meta_json, jsons.dsn_json, jsons.connect_args_json
+            get_connection_registry(),
+            datasource_id,
+            jsons.meta_json,
+            jsons.dsn_json,
+            jsons.connect_args_json,
         )
 
         return datasource_id

--- a/tests/test_sql_magic_meta_commands.py
+++ b/tests/test_sql_magic_meta_commands.py
@@ -11,7 +11,7 @@ import pytest
 from IPython.display import HTML
 from sqlalchemy.engine.reflection import Inspector
 
-from noteable.sql.connection import Connection
+from noteable.sql.connection import get_sqla_connection
 from noteable.sql.gate_messaging_types import RelationStructureDescription
 from noteable.sql.meta_commands import (
     IntrospectAndStoreDatabaseCommand,
@@ -89,8 +89,7 @@ class TestListSchemas:
         r"""Prove that when no views exist, \schemas+ does not talk at all about a 'View Count' column"""
 
         # Drop the view.
-        connection = Connection.connections['@sqlite']
-        db = connection.sqla_connection
+        db = get_sqla_connection("@sqlite")
         db.execute('drop view str_int_view')
 
         sql_magic.execute(r'@sqlite \schemas+')


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [x] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

The inherited code from sql_magics had the Connection class playing double-duty as both the instances of connections as well as the registry of connections.

Separate these two roles in order to begin to pave the way for a class hierarchy of Connection types so that we can model the variations in our SQLAlchemy connection types more cleanly. This will let us more cleanly fix some existing bugs, model variations in warts in SQLA dialects, esp. at introspection time, better and more cleanly, as well as clear the road for implementing non-SQLA and even non-SQL text queryable connection types / integrations. Am initially eyeballing Jira / JQL as a MVP destination for this line of refactoring, but can see how getting much more of the functionality currently done inflexibly in a procedural fashion over in magics.py and meta_commands.py to end up being done object-oriented in Connection hierarchy classes will be key for:
  * Non-SQLA but still more or less SQL datasources (separate class family for SQLAConnection from Connection)
  * Non-SQL datasources (separate class family / classes distinct from SQLAConnection) that can still return rectangular dataframe-able data given a text query (Jira / JQL)
  * Constrain SQLA-dialect eccentricies (BigQuery, Snowflake) and warty workarounds into their specific SQLAConnection subclasses. Having single concrete classes holding the warts for all of the lifecycle uses of a given dialect will be much cleaner than having those warts smeared throughout the codebase, then leaving a reader to wonder 'how exactly does BigQuery differ from PostgreSQL for our purposes?'.

Review would probably be done most easily through pull down the branch and reading the entirety of the resulting connection.py file. The diff view read is a nightmare, but the new module contents I like much, much better. But can then use the diff view read for the other files. The changes to interacting modules, namely datasources.py for the bootstrapping code and magic.py for the actual run a SQL magic invocation are reasonable and are ain improvement overall IMO. For example, bootstrapping duckdb is now done in the datasources module when bootstrapping all the others.

But first things first --- will need to have variation in the connection classes, but only need one single registry of connections implementation.

All tests passing, new tests written. 99% coverage over connection.py module, lacking coverage for exception raised when not SQLAlchemy based (future expansion). Lots of changes to the tests because of the poor ways they had to get at the known registered connections beforehand.


The existing toplevel documented convenience getters exposed in `noteable.sql` for within-notebook-use remain:
  * `get_sqla_connection`
  * `get_sqla_engine`
 
and functionality remains constant, as indicated by untouched `noteable.sql.__init__.py` . New tests written proving their existence and functionality, `tests/test_sql_init_package.py`


See [this project proposal](https://docs.google.com/document/d/1mYZp5O4IlqFi1IexLdCtr8ihnEq6KWzbDJGzpnHnjDo/edit) for the bigger scope.