### PR TITLE
Fix bug where refactored bootstrap_datasource()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Split registry vs. connection modeling roles: `noteable.sql.connection.Connection` class vs `noteable.sql.connection.ConnectionRegistry` class.
-
+- Fix bootstrap_datasource() passing along of create_engine_kwargs, otherwise misery.
 ### Added
 - `%ntbl change-log-level --rtu-level DEBUG` will update relevant Sending, PA, and Origami libraries to render useful debug logs related to RTU processing in PA
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -397,6 +397,7 @@ class DatasourceJSONs:
     meta_dict: Dict[str, Any]
     dsn_dict: Optional[Dict[str, str]] = None
     connect_args_dict: Optional[Dict[str, any]] = None
+    expect_identical_connect_args: bool = True
 
     @property
     def meta_json(self) -> str:

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -287,6 +287,7 @@ class SampleData:
             connect_args_dict={
                 'max_download_seconds': '22',
             },
+            expect_identical_connect_args=False,
         ),
         'awsathena': DatasourceJSONs(
             meta_dict={
@@ -412,6 +413,12 @@ class TestBootstrapDatasources:
         for ds_id, sample in id_and_samples:
             assert f'@{ds_id}' in registry
             assert sample.meta_dict['name'] in registry
+
+            # Ensure that the Connection actually got bootstrapped with
+            # the connect_args, otherwise bootstrap_datasource() messed up badly.
+            if sample.connect_args_dict and sample.expect_identical_connect_args:
+                con = registry.get(f'@{ds_id}')
+                assert con._create_engine_kwargs == {'connect_args': sample.connect_args_dict}
 
         # (Let test TestBootstrapDatasource focus on the finer-grained details)
 


### PR DESCRIPTION

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [x] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix bug where refactored bootstrap_datasource()  -> connection_registry.factory_and_register() was dropping create_engine_kwargs. Whoops.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Datasources that needed to pass over create_engine_kwargs / connect_args would fail to be configured properly. That ... didn't include the PostgreSQL I manually clicktested with on Staging.
- No test case covered proving these facts make it down to the create_engine() call.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- They will work.
- New test proving that they make it over.