### PR TITLE
Defer data connection creation/bootstrapping until first use 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Split registry vs. connection modeling roles: `noteable.sql.connection.Connection` class vs `noteable.sql.connection.ConnectionRegistry` class.
 - Fix bootstrap_datasource() passing along of create_engine_kwargs, otherwise misery.
+- Defer data connection bootstrapping until first need, instead of at kernel launch time.
 ### Added
 - `%ntbl change-log-level --rtu-level DEBUG` will update relevant Sending, PA, and Origami libraries to render useful debug logs related to RTU processing in PA
 

--- a/noteable/__init__.py
+++ b/noteable/__init__.py
@@ -3,7 +3,7 @@ import pkg_resources
 __version__ = pkg_resources.get_distribution("noteable").version
 
 from .data_loader import NoteableDataLoaderMagic
-from .datasources import bootstrap_datasources
+from .datasources import discover_datasources
 from .logging import configure_logging
 from .ntbl import NTBLMagic
 from .sql.magic import SqlMagic
@@ -12,8 +12,9 @@ from .sql.magic import SqlMagic
 def load_ipython_extension(ipython):
     configure_logging(False, "INFO", "DEBUG")
 
-    # Initialize any remote datasource connections.
-    bootstrap_datasources()
+    # Learn what datasources are available from Vault injector, and prepare to bootstrap
+    # them if / when needed.
+    discover_datasources()
 
     # Register all of our magics.
     ipython.register_magics(NoteableDataLoaderMagic, NTBLMagic, SqlMagic)

--- a/noteable/datasources.py
+++ b/noteable/datasources.py
@@ -1,4 +1,5 @@
-"""External datasource / database connection management bridging Noteable and ipython-sql"""
+"""External datasource / database connection management"""
+from functools import partial
 import json
 import subprocess
 import sys
@@ -10,7 +11,7 @@ import structlog
 from sqlalchemy.engine import URL
 
 # ipython-sql thinks mighty highly of isself with this package name.
-from noteable.sql.connection import ConnectionRegistry, get_connection_registry
+from noteable.sql.connection import ConnectionRegistry, Connection, get_connection_registry
 from noteable.sql.run import add_commit_blacklist_dialect
 
 DEFAULT_SECRETS_DIR = Path('/vault/secrets')
@@ -20,11 +21,13 @@ from noteable.datasource_postprocessing import post_processor_by_drivername
 logger = structlog.get_logger(__name__)
 
 
-def bootstrap_datasources(secrets_dir: Union[Path, str] = DEFAULT_SECRETS_DIR):
-    """Digest all of the datasource files Vault injector has created for us and
-    inject into ipython-sql as their Connection objects.
+def discover_datasources(secrets_dir: Union[Path, str] = DEFAULT_SECRETS_DIR):
+    """Discover all of the possible datasource configurations that the Vault injector has
+    left for us. Register a callback with the connection registry on how to configure
+    each one if / when needed when the first time a cell referencing their cell handle
+    is used.
 
-    Also register the local memory DuckDB global datasource.
+    Also register callback for the implicit local memory DuckDB global datasource.
     """
 
     connection_registry: ConnectionRegistry = get_connection_registry()
@@ -35,16 +38,17 @@ def bootstrap_datasources(secrets_dir: Union[Path, str] = DEFAULT_SECRETS_DIR):
     # Look for *.meta.json files.
     for ds_meta_json_path in secrets_dir.glob('*.meta_js'):
         # Derive filenames for the expected related files
-        bootstrap_datasource_from_files(connection_registry, ds_meta_json_path)
+        queue_bootstrap_datasource_from_files(connection_registry, ds_meta_json_path)
 
-    # Also bootstrap the omnipresent mighty DuckDB!
-    bootstrap_duckdb(connection_registry)
+    # Also inform the registry on how to bootstrap the omnipresent mighty DuckDB if/when needed.
+    # (is external function 'cause test suite uses it also.)
+    queue_bootstrap_duckdb(connection_registry)
 
 
-def bootstrap_datasource_from_files(
+def queue_bootstrap_datasource_from_files(
     connection_registry: ConnectionRegistry, ds_meta_json_path: Path
 ):
-    """Bootstrap a single datasource from files given reference to the meta json file
+    """Register bootstraper for a single datasource from files given reference to the meta json file
 
     Assumes the other two files are peers in the directory and named accordingly
     """
@@ -67,19 +71,38 @@ def bootstrap_datasource_from_files(
     else:
         connect_args_json = None
 
-    bootstrap_datasource(connection_registry, basename, meta_json, dsn_json, connect_args_json)
+    # Must look into metadata to at least get the human name before registering the rest of bootstrapping.
+    metadata = json.loads(meta_json)
+    datasource_id = basename
+
+    bootstrapper = partial(
+        bootstrap_datasource,
+        datasource_id=datasource_id,
+        metadata=metadata,
+        dsn_json=dsn_json,
+        connect_args_json=connect_args_json,
+    )
+
+    sql_cell_handle = f'@{basename}'
+    human_name = metadata['name']
+
+    # The registry will call the bootstrapper function if/when this datasource is needed.
+    connection_registry.register_datasource_bootstrapper(sql_cell_handle, human_name, bootstrapper)
 
 
 def bootstrap_datasource(
-    connection_registry: ConnectionRegistry,
     datasource_id: str,
-    meta_json: str,
+    metadata: dict,
     dsn_json: Optional[str],
     connect_args_json: Optional[str],
-):
+) -> Connection:
     """Bootstrap this single datasource from its three json definition JSON sections"""
 
-    metadata = json.loads(meta_json)
+    if not isinstance(metadata, dict):
+        # This param changed type recently, catch it early.
+        raise ValueError(
+            f'bootstrap_datasource() expects `metadata` to be passed in as a dict, got {type(metadata)}'
+        )
 
     # Yes, bigquery connections may end up with nothing in dsn_json.
     dsn_dict = json.loads(dsn_json) if dsn_json else {}
@@ -97,66 +120,56 @@ def bootstrap_datasource(
     pre_process_dict(dsn_dict)
     pre_process_dict(connect_args)
 
-    # human-given name for the datasource is more likely than not present in the metadata
-    # ('old' datasources in integration, staging, app.noteable.world may lack)
-    human_name = metadata.get('name', 'Unnamed legacy connection')
+    # Do any per-drivername post-processing of and dsn_dict and create_engine_kwargs
+    # before we make use of any of their contents. Post-processors may end up rejecting this
+    # configuration, so catch and handle just like a failure when calling Connection.set().
+    if drivername in post_processor_by_drivername:
+        post_processor: Callable[[str, dict, dict], None] = post_processor_by_drivername[drivername]
+        post_processor(datasource_id, dsn_dict, create_engine_kwargs)
 
+    # Ensure the required driver packages are installed already, or, if allowed,
+    # install them on the fly.
+    ensure_requirements(
+        datasource_id,
+        metadata['required_python_modules'],
+        metadata['allow_datasource_dialect_autoinstall'],
+    )
+
+    # Prepare connection URL string.
+    url_obj = URL.create(**dsn_dict)
+    connection_url = str(url_obj)
+
+    # XXX TODO, make a mixin for future SQLAlchemy DisableAutoCommit subclasses incorporating
+    # this particular need. A good look for the end game here may be that most all of this
+    # 'bootstrapping datasource' code will be within either the Connection base class stuff, unifying
+    # this module with Connection module, or perhaps a slightly parallel class hierarchy for
+    # the bootstrapping class corresponding to the Connection subtype registered for the
+    # drivername field?
+
+    # Do we need to tell sql-magic to not try to emit a COMMIT after each statement
+    # according to the needs of this driver?
+    if not metadata['sqlmagic_autocommit']:
+        # A sqlalchemy drivername may be comprised of 'dialect+drivername', such as
+        # 'databricks+connector'.
+        # If so, then we must only pass along the LHS of the '+'.
+        dialect = metadata['drivername'].split('+')[0]
+        add_commit_blacklist_dialect(dialect)
+
+    # Register the connection + return it.
     sql_cell_handle = f'@{datasource_id}'
 
-    try:
-        # Do any per-drivername post-processing of and dsn_dict and create_engine_kwargs
-        # before we make use of any of their contents. Post-processors may end up rejecting this
-        # configuration, so catch and handle just like a failure when calling Connection.set().
-        if drivername in post_processor_by_drivername:
-            post_processor: Callable[[str, dict, dict], None] = post_processor_by_drivername[
-                drivername
-            ]
-            post_processor(datasource_id, dsn_dict, create_engine_kwargs)
+    # XXX Todo: polymorphy / mapping connection subclass to construct based on driver name
+    # will happen here once we have a class hierarchy. Until then, only exactly one class
+    # to construct!
 
-        # Ensure the required driver packages are installed already, or, if allowed,
-        # install them on the fly.
-        ensure_requirements(
-            datasource_id,
-            metadata['required_python_modules'],
-            metadata['allow_datasource_dialect_autoinstall'],
-        )
+    connection = Connection(
+        sql_cell_handle=sql_cell_handle,
+        human_name=metadata['name'],
+        connection_url=connection_url,
+        **create_engine_kwargs,
+    )
 
-        # Prepare connection URL string.
-        url_obj = URL.create(**dsn_dict)
-        connection_url = str(url_obj)
-
-        # XXX TODO, make a mixin for future SQLAlchemy DisableAutoCommit subclasses incorporating
-        # this particular need. A good look for the end game here may be that most all of this
-        # 'bootstrapping datasource' code will be within either the Connection base class stuff, unifying
-        # this module with Connection module, or perhaps a slightly parallel class hierarchy for
-        # the bootstrapping class corresponding to the Connection subtype registered for the
-        # drivername field?
-
-        # Do we need to tell sql-magic to not try to emit a COMMIT after each statement
-        # according to the needs of this driver?
-        if not metadata['sqlmagic_autocommit']:
-            # A sqlalchemy drivername may be comprised of 'dialect+drivername', such as
-            # 'databricks+connector'.
-            # If so, then we must only pass along the LHS of the '+'.
-            dialect = metadata['drivername'].split('+')[0]
-            add_commit_blacklist_dialect(dialect)
-
-        # Register the connection!
-        connection_registry.factory_and_register(
-            sql_cell_handle, human_name, connection_url, **create_engine_kwargs
-        )
-
-    except Exception as e:
-        # Exception from either post_processor(), ensure_requirements(), or factory_and_register() when
-        # it actually constructs the engine.
-        logger.exception(
-            'Unable to bootstrap datasource',
-            datasource_id=datasource_id,
-            human_name=human_name,
-        )
-
-        # Remember the failure so can be shown if / when human tries to use the connection.
-        connection_registry.add_bootstrapping_failure(sql_cell_handle, human_name, str(e))
+    return connection
 
 
 ##
@@ -241,9 +254,18 @@ LOCAL_DB_CONN_NAME = "Local Database"
 DUCKDB_LOCATION = "duckdb:///:memory:"
 
 
-def bootstrap_duckdb(registry: ConnectionRegistry):
-    registry.factory_and_register(
+def local_duckdb_bootstrapper() -> Connection:
+    """Return the noteable.sql.connection.Connection to use for local memory DuckDB."""
+    return Connection(
         sql_cell_handle=LOCAL_DB_CONN_HANDLE,
         human_name=LOCAL_DB_CONN_NAME,
         connection_url=DUCKDB_LOCATION,
+    )
+
+
+def queue_bootstrap_duckdb(registry: ConnectionRegistry):
+    registry.register_datasource_bootstrapper(
+        sql_cell_handle=LOCAL_DB_CONN_HANDLE,
+        human_name=LOCAL_DB_CONN_NAME,
+        bootstrapper=local_duckdb_bootstrapper,
     )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -22,32 +22,6 @@ class TestConnection:
 
 
 class TestConnectionRegistry:
-    def test_hates_null_connection(self):
-        registry = get_connection_registry()
-        with pytest.raises(ValueError, match='must be a Connection instance'):
-            registry.register(None)
-
-    def test_hates_double_registration(self, sqlite_database_connection):
-        # The sqlite_database_connection fixture will have already registered it.
-        registry = get_connection_registry()
-
-        handle, human_name = sqlite_database_connection
-
-        with pytest.raises(ValueError, match='is already registered'):
-            registry.register(Connection(handle, human_name, 'sqlite:///:memory:'))
-
-    def tests_hates_double_reported_bootstrapping_failures(self, sqlite_database_connection):
-        registry = get_connection_registry()
-
-        handle, human_name = sqlite_database_connection
-
-        with pytest.raises(
-            ValueError, match='s already defined, but now reporting bootstrapping failure'
-        ):
-            registry.add_bootstrapping_failure(
-                handle, human_name, 'Whacktastical late error reporting, Batman!'
-            )
-
     def test_can_find_by_either_sql_cell_handle_or_human_name(self, sqlite_database_connection):
         registry = get_connection_registry()
 
@@ -56,6 +30,44 @@ class TestConnectionRegistry:
         assert registry.get(handle) == registry.get(human_name) and isinstance(
             registry.get(handle), Connection
         )
+
+    def test_register_datasource_bootstrapper_hates_malformed_cell_handle(self):
+        with pytest.raises(ValueError, match='sql_cell_handle must be provided and start with "@"'):
+            get_connection_registry().register_datasource_bootstrapper('bad', 'foo', lambda: None)
+
+    def test_register_datasource_bootstrapper_hates_bootstrapper_not_callable(self):
+        with pytest.raises(
+            TypeError, match='Data connection bootstrapper functions must be zero-arg callables'
+        ):
+            get_connection_registry().register_datasource_bootstrapper('@bad', 'foo', None)
+
+    def test_registry_hates_if_bootstrapper_returns_non_connection(self):
+        registry = get_connection_registry()
+
+        registry.register_datasource_bootstrapper('@123', '123', lambda: None)
+        with pytest.raises(TypeError, match='returned something other than a Connection instance'):
+            registry.get('@123')
+
+    def test_register_hates_null_connection(self):
+        registry = get_connection_registry()
+        with pytest.raises(ValueError, match='must be a Connection instance'):
+            registry._register(None)
+
+    def test_register_hates_double_registration(self, sqlite_database_connection):
+        # The sqlite_database_connection fixture will have already registered it.
+        registry = get_connection_registry()
+
+        handle, human_name = sqlite_database_connection
+
+        # Force the already queued-for-bootstrapping mapping to make it all the way ...
+        existing_conn = registry.get(handle)
+
+        # Will first complain about the handle collision
+        with pytest.raises(ValueError, match=f'with handle {handle} is already registered'):
+            registry._register(Connection(handle, human_name, 'sqlite:///:memory:'))
+
+        with pytest.raises(ValueError, match=f'with human name {human_name} is already registered'):
+            registry._register(Connection(handle + 'sdfsdf', human_name, 'sqlite:///:memory:'))
 
 
 class TestGetNoteableConnection:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Defer data source / data connection bootstrapping until first use, instead of all at once at kernel startup

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- All datasources are bootstrapped into the registry at kernel startup time, making startup take longer (esp. for BigQuery and other datasource types which reach out to network at creation time).
- Errors from bootstrapping need to be cached within the registry.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- First use within a SQL cell (or tprogrammatically rying to obtain via `noteable.sql.get_noteable_connection()` or ilk) will then bootstrap the datasource.
- Any bootstrapping errors can be simply raised and the cell running them will show the direct exception.