### PR TITLE
Fixes from clicktesting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split registry vs. connection modeling roles: `noteable.sql.connection.Connection` class vs `noteable.sql.connection.ConnectionRegistry` class.
 - Fix bootstrap_datasource() passing along of create_engine_kwargs, otherwise misery.
 - Defer data connection bootstrapping until first need, instead of at kernel launch time.
+- Force all SQLAlchemy datasource subtypes to be their own individual concrete classes individually declaring their own needs_explicit_commit value for sanity, correctness, and clarity.
+  - Stop expecting sqlmagic_autocommit being presented in gate-side metadata. Only consider the SQLAlchemy subtype's classlevel boolean. The field will be removed from Gate side in future work.
+- Athena does _must not_  `quote_plus(connect_args['s3_staging_dir'])` -- they won't work encoded that way. It wants direct passing. Not sure where I got that idea.
+
 ### Added
 - `%ntbl change-log-level --rtu-level DEBUG` will update relevant Sending, PA, and Origami libraries to render useful debug logs related to RTU processing in PA
 

--- a/noteable/sql/sqlalchemy.py
+++ b/noteable/sql/sqlalchemy.py
@@ -15,7 +15,7 @@ import sqlalchemy
 import structlog
 from sqlalchemy.engine import URL, CursorResult, Dialect
 
-from .connection import BaseConnection, ResultSet, connection_class
+from noteable.sql.connection import BaseConnection, ResultSet, connection_class
 
 logger = structlog.get_logger(__name__)
 
@@ -53,18 +53,15 @@ class SQLAlchemyResult(ResultSet):
             self.has_results_to_report = False
 
 
-@connection_class('mysql+pymysql')
-@connection_class('mysql+mysqldb')
-@connection_class('redshift+redshift_connector')
-@connection_class('singlestoredb')
-@connection_class('trino')
 class SQLAlchemyConnection(BaseConnection):
-    """Base class for all SQLAlchemy-based Connection implementations"""
+    """Base class for all SQLAlchemy-based Connection implementations. Each type _must_ make
+    and register a subclass, at very least to define value for cls.needs_explicit_commit"""
+
+    needs_explicit_commit: bool
+    """Will there be an implicit transaction open which demands commit()ing between execute() calls?"""
 
     is_sqlalchemy_based: bool = True
-    needs_explicit_commit: bool = True
-
-    """Do we need to explicitly commit() after executing a statement? See `execute()`"""
+    """Is this connection type implemented on top of SQLAlchemy?"""
 
     def __init__(
         self,
@@ -102,9 +99,6 @@ class SQLAlchemyConnection(BaseConnection):
         human_name = metadata['name']
 
         super().__init__(cell_handle, human_name)
-
-        if 'sqlmagic_autocommit' in metadata:
-            self.needs_explicit_commit = metadata['sqlmagic_autocommit']
 
         connection_url = str(URL.create(**dsn_dict))
 
@@ -181,6 +175,8 @@ class SQLAlchemyConnection(BaseConnection):
 
 @connection_class('awsathena+rest')
 class AwsAthenaConnection(SQLAlchemyConnection):
+    needs_explicit_commit: bool = False
+
     @classmethod
     def preprocess_configuration(
         cls, datasource_id: str, dsn_dict: Dict[str, Any], create_engine_kwargs: Dict[str, Any]
@@ -189,7 +185,6 @@ class AwsAthenaConnection(SQLAlchemyConnection):
 
             1. Host will be just the region name. Expand to -> athena.{region_name}.amazonaws.com
             2. Username + password will be AWS access key id + secret value. Needs to be quote_plus protected.
-            3. Likewise the 's3_staging_dir' present in create_engine_kwargs.
 
         See https://github.com/laughingman7743/PyAthena/
         """
@@ -201,13 +196,11 @@ class AwsAthenaConnection(SQLAlchemyConnection):
         dsn_dict['username'] = quote_plus(dsn_dict['username'])
         dsn_dict['password'] = quote_plus(dsn_dict['password'])
 
-        # 3. quote_plus s3_staging_dir
-        connect_args = create_engine_kwargs['connect_args']
-        connect_args['s3_staging_dir'] = quote_plus(connect_args['s3_staging_dir'])
-
 
 @connection_class('bigquery')
 class BigQueryConnection(SQLAlchemyConnection):
+    needs_explicit_commit: bool = False
+
     @classmethod
     def preprocess_configuration(
         cls, datasource_id: str, dsn_dict: Dict[str, Any], create_engine_kwargs: Dict[str, Any]
@@ -264,6 +257,8 @@ class BigQueryConnection(SQLAlchemyConnection):
 
 @connection_class('clickhouse+http')
 class ClickhouseConnection(SQLAlchemyConnection):
+    needs_explicit_commit: bool = False
+
     @classmethod
     def preprocess_configuration(
         cls, datasource_id: str, dsn_dict: Dict[str, Any], create_engine_kwargs: Dict[str, Any]
@@ -298,6 +293,8 @@ class ClickhouseConnection(SQLAlchemyConnection):
 
 @connection_class('databricks+connector')
 class DatabricksConnection(SQLAlchemyConnection):
+    needs_explicit_commit: bool = False
+
     DATABRICKS_CONNECT_SCRIPT_TIMEOUT = 10
 
     @classmethod
@@ -371,8 +368,19 @@ class DuckDBConnection(SQLAlchemyConnection):
     needs_explicit_commit = False
 
 
+@connection_class('mysql+pymysql')
+@connection_class('mysql+mysqldb')
+@connection_class('singlestoredb')
+class MySQLFamilyConnection(SQLAlchemyConnection):
+    """Base class for all SQLAlchemy-based Connection implementations"""
+
+    needs_explicit_commit: bool = False
+
+
 @connection_class('mssql+pyodbc')
 class MsSqlConnection(SQLAlchemyConnection):
+    needs_explicit_commit: bool = False
+
     @classmethod
     def preprocess_configuration(
         cls, datasource_id: str, dsn_dict: Dict[str, Any], create_engine_kwargs: Dict[str, Any]
@@ -449,8 +457,15 @@ class PostgreSQLConnection(SQLAlchemyConnection):
             cls._installed_psycopg2_interrupt_fix = True
 
 
+@connection_class('redshift+redshift_connector')
+class Redshift(SQLAlchemyConnection):
+    needs_explicit_commit: bool = True
+
+
 @connection_class('snowflake')
 class SnowflakeConnection(SQLAlchemyConnection):
+    needs_explicit_commit: bool = True
+
     @classmethod
     def preprocess_configuration(
         cls, datasource_id: str, dsn_dict: Dict[str, Any], create_engine_kwargs: Dict[str, Any]
@@ -543,3 +558,10 @@ class SQLiteConnection(SQLAlchemyConnection):
                 raise ValueError(
                     f'SQLite database files should be located within /tmp, got "{cur_path}"'
                 )
+
+
+@connection_class('trino')
+class TrinoConnection(SQLAlchemyConnection):
+    """Trino connection type"""
+
+    needs_explicit_commit: bool = False

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -85,7 +85,6 @@ class SampleData:
                 'required_python_modules': ['sqlalchemy-cockroachdb', 'psycopg2'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'cockroachdb',
-                'sqlmagic_autocommit': False,
                 'name': 'My CRDB',
             },
             dsn_dict={
@@ -101,7 +100,6 @@ class SampleData:
                 'required_python_modules': ['psycopg2'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'postgresql',
-                'sqlmagic_autocommit': True,
                 'name': 'My PostgreSQL',
             },
             dsn_dict={
@@ -117,7 +115,6 @@ class SampleData:
                 'required_python_modules': ['psycopg2'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'postgresql',
-                'sqlmagic_autocommit': True,
                 'name': 'My PostgreSQL SSL',
             },
             dsn_dict={
@@ -135,7 +132,6 @@ class SampleData:
                 # Packages installed already in noteable-notebook-magics
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'redshift+redshift_connector',
-                'sqlmagic_autocommit': True,
                 'name': 'My RedShift',
             },
             dsn_dict={
@@ -151,7 +147,6 @@ class SampleData:
                 'required_python_modules': ['trino[sqlalchemy]'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'trino',
-                'sqlmagic_autocommit': False,  # This one is special!
                 'name': 'My Trino',
             },
             dsn_dict={
@@ -166,7 +161,6 @@ class SampleData:
                 'required_python_modules': ['sqlalchemy-databricks'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'databricks+connector',
-                'sqlmagic_autocommit': False,  # This one is special!
                 'name': 'My Databricks',
             },
             dsn_dict={
@@ -187,7 +181,6 @@ class SampleData:
                 'required_python_modules': ['snowflake-sqlalchemy'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'snowflake',
-                'sqlmagic_autocommit': True,
                 'name': 'My Snowflake',
             },
             dsn_dict={
@@ -204,7 +197,6 @@ class SampleData:
                 'required_python_modules': ['snowflake-sqlalchemy'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'snowflake',
-                'sqlmagic_autocommit': True,
                 'name': 'My Snowflake with database',
             },
             dsn_dict={
@@ -222,7 +214,6 @@ class SampleData:
                 'required_python_modules': ['snowflake-sqlalchemy'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'snowflake',
-                'sqlmagic_autocommit': True,
                 'name': 'Snowflake with database and schema',
             },
             dsn_dict={
@@ -241,7 +232,6 @@ class SampleData:
                 'required_python_modules': ['snowflake-sqlalchemy'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'snowflake',
-                'sqlmagic_autocommit': True,
                 'name': 'Snowflake with empty db and schema',
             },
             dsn_dict={
@@ -260,7 +250,6 @@ class SampleData:
                 'required_python_modules': [],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'sqlite',
-                'sqlmagic_autocommit': False,
                 'name': 'Explicit Memory SQLite',
             },
             dsn_dict={
@@ -272,7 +261,6 @@ class SampleData:
                 'required_python_modules': [],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'sqlite',
-                'sqlmagic_autocommit': False,
                 'name': 'Implicit Memory SQLite',
             },
             dsn_dict={
@@ -285,7 +273,6 @@ class SampleData:
                 'required_python_modules': [],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'sqlite',
-                'sqlmagic_autocommit': False,
                 'name': 'Memory SQLite with max_download',
             },
             dsn_dict={
@@ -302,7 +289,6 @@ class SampleData:
                 'required_python_modules': ["PyAthena[SQLAlchemy]"],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'awsathena+rest',
-                'sqlmagic_autocommit': False,
                 'name': 'My AWS Athena',
             },
             dsn_dict={
@@ -312,7 +298,6 @@ class SampleData:
                 'database': 'default_database',
             },
             connect_args_dict={'s3_staging_dir': 's3://myamazonawsbucket/results/'},
-            expect_identical_connect_args=False,
         ),
         # Originally, we used pymysql for SingleStore, mysql, mariadb.
         # Older generation datasource data in Vault will still request to use this driver
@@ -322,7 +307,6 @@ class SampleData:
                 'required_python_modules': ["pymysql"],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'mysql+pymysql',
-                'sqlmagic_autocommit': False,
                 'name': 'Old Singlestore',
             },
             dsn_dict={
@@ -339,7 +323,6 @@ class SampleData:
                 'required_python_modules': ["sqlalchemy-singlestoredb"],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'singlestoredb',
-                'sqlmagic_autocommit': False,
                 'name': 'New Singlestore',
             },
             dsn_dict={
@@ -356,7 +339,6 @@ class SampleData:
                 'required_python_modules': ["pymysql"],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'mysql+pymysql',
-                'sqlmagic_autocommit': False,
                 'name': 'Old Mariadb',
             },
             dsn_dict={
@@ -373,7 +355,6 @@ class SampleData:
                 'required_python_modules': ["mysqlclient"],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'mysql+mysqldb',
-                'sqlmagic_autocommit': False,
                 'name': 'New Mariadb',
             },
             dsn_dict={
@@ -427,6 +408,13 @@ class TestBootstrapDatasources:
             # Now cause it to actually get bootstrapped by asking for it.
             conn = registry.get(handle)
             assert isinstance(conn, Connection)
+
+            if conn.is_sqlalchemy_based:
+                # Must be an explicit subclass.
+                assert type(conn) is not SQLAlchemyConnection
+
+                # Must be explicitly declared in the subtype.
+                assert conn.needs_explicit_commit in (True, False)
 
             # Ensure that the Connection actually got bootstrapped with
             # the connect_args, otherwise bootstrap_datasource() messed up badly.
@@ -489,18 +477,12 @@ class TestBootstrapDatasource:
                 # Can only work this way also if the datasource name was present in meta-json.
                 assert the_conn._engine is get_sqla_engine(expected_human_name)
 
-            if 'sqlmagic_autocommit' in case_data.meta_dict:
-                assert the_conn.needs_explicit_commit == (
-                    case_data.meta_dict['sqlmagic_autocommit']
-                )
-
     def test_broken_postgres_is_silent_noop(self, datasource_id):
         case_data = DatasourceJSONs(
             meta_dict={
                 'required_python_modules': ['psycopg2'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'postgresql',
-                'sqlmagic_autocommit': True,
                 'name': 'My PostgreSQL',
             },
             dsn_dict={
@@ -539,7 +521,6 @@ class TestBootstrapDatasource:
                 'required_python_modules': ['psycopg2-binary'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'postgresql',
-                'sqlmagic_autocommit': True,
                 'name': 'My PostgreSQL',
             },
             dsn_dict={
@@ -579,7 +560,6 @@ class TestBootstrapDatasource:
                 'required_python_modules': ['sqlalchemy-bigquery'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'bigquery',
-                'sqlmagic_autocommit': True,
                 'name': 'My bigquery',
             },
             connect_args_dict={
@@ -708,7 +688,6 @@ class TestDatabricks:
                 'required_python_modules': ['sqlalchemy-databricks'],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'databricks+connector',
-                'sqlmagic_autocommit': False,  # This one is special!
                 'name': 'Databricks With Extras',
             },
             dsn_dict={
@@ -1002,7 +981,6 @@ class TestSQLite:
                     'required_python_modules': [],
                     'allow_datasource_dialect_autoinstall': False,
                     'drivername': 'sqlite',
-                    'sqlmagic_autocommit': False,
                     'name': 'Download file sqlite',
                 },
                 dsn_dict={
@@ -1067,7 +1045,6 @@ class TestSQLite:
                 'required_python_modules': [],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'sqlite',
-                'sqlmagic_autocommit': False,
                 'name': human_name,
             },
             dsn_dict={
@@ -1161,7 +1138,7 @@ def test_postprocess_snowflake(dsn_dict, expected):
                     'password': 'MMHq%3A%2F',
                 },
                 # resulting connect args dict
-                {'connect_args': {'s3_staging_dir': 's3%3A%2F%2Fmyamazonbucket%2Fresults%2F'}},
+                {'connect_args': {'s3_staging_dir': 's3://myamazonbucket/results/'}},
             ),
         ),
     ],

--- a/tests/test_sql_magic.py
+++ b/tests/test_sql_magic.py
@@ -479,7 +479,6 @@ class TestSQLite:
                 'required_python_modules': [],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'sqlite',
-                'sqlmagic_autocommit': False,
                 'name': human_name,
             },
             dsn_dict={
@@ -532,7 +531,6 @@ class TestAmazonAthena:
                 'required_python_modules': ["PyAthena[SQLAlchemy]"],
                 'allow_datasource_dialect_autoinstall': False,
                 'drivername': 'awsathena+rest',
-                'sqlmagic_autocommit': False,
                 'name': 'My AWS Athena',
             },
             dsn_dict={


### PR DESCRIPTION
- Force all SQLAlchemy datasource subtypes to be their own individual concrete classes individually declaring their own `needs_explicit_commit` value for sanity, correctness, and clarity.
  - Stop expecting `sqlmagic_autocommit` being presented in gate-side metadata. Only consider the SQLAlchemy subtype's classlevel boolean. The field will be removed from Gate side in future work.
- Athena does _must not_  `quote_plus(connect_args['s3_staging_dir'])` -- they won't work encoded that way. It wants direct passing. Not sure where I got the idea that they had to be, but it doesn't work with 'em encoded this way, and the driver docs only say have to quote_plus username + password.


[This staging notebook](https://app.noteable-staging.us/f/5aa243f3-fcd7-4319-b907-c196badcc970/Test-Autocommit-Settings.ipynb) has the current contents of this branch's datasources.py with all these type declarations, and tests against all the datasource types except for Singlestore (I can't get the Singlestore cloud cluster booted at this time, have opened trouble ticket with them).

This work is the result of clicking through that notebook to see that they all basically work, and fixing the bugs where they didn't.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [x] Have you validated this change locally?
