### PR TITLE
Copy metadata dict to avoid mutating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repackaged all code to be in 'noteable' toplevel package, not 'noteable_magics.'
 - Better datasets download progress bars
 
+### Fixed
+- Don't mutate `metadata` passed to `bootstrap_datasource()`
+  - Previously, a `KeyError` would be raised, hiding the underlying error when creating a connection
+
 ## [2.0.0] - 2022-03-15
 ### Changed
 - Upgrade `ipython` to `^7.31.1` for security fix

--- a/noteable/datasources.py
+++ b/noteable/datasources.py
@@ -108,6 +108,8 @@ def bootstrap_datasource(
             f'bootstrap_datasource() expects `metadata` to be passed in as a dict, got {type(metadata)}'
         )
 
+    metadata = metadata.copy()  # don't mutate the mutable metadata passed to us
+
     # Yes, bigquery connections may end up with nothing in dsn_json.
     dsn_dict = json.loads(dsn_json) if dsn_json else {}
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [ ] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Don't mutate `metadata` passed to `bootstrap_datasource()`

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- a `KeyError` would be raised, hiding the underlying error when creating a connection. In our case, `port` was an empty string when it should be `None`

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- No `KeyError` is raised
