### PR TITLE
Fix Redshift vs view definitions

### DIFF
--- a/noteable/sql/sqlalchemy/__init__.py
+++ b/noteable/sql/sqlalchemy/__init__.py
@@ -29,6 +29,7 @@ from .utils import (
     BigQueryInspector,
     CockroachDBInspector,
     MySQLInspector,
+    RedshiftInspector,
     SQLAlchemyResult,
     WrappedInspector,
 )
@@ -489,7 +490,9 @@ class PostgreSQLConnection(BasePostgreSQLConnection):
 
 
 @connection_class('redshift+redshift_connector')
-class Redshift(IntrospectableSQLAlchemyConnection):
+class RedshiftConnection(IntrospectableSQLAlchemyConnection):
+    inspector_class = RedshiftInspector
+
     needs_explicit_commit: bool = True
 
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Unit tests are present
- [x] Have you validated this change locally?

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Redshift dialect returns text() objects from get_view_definition(), surprising things and preventing encapsulation into pydantic message expecting exactly str. So capture and expliclty str() downgrade.

## What is the Current Behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

- Cannot introspect Redshift databases that have views.

## What is the New Behavior?

<!-- Please describe the behavior or changes that are being added by this PR. Examples of updated API payloads are encouraged! -->

- Introspection succeeds.
